### PR TITLE
feat: support locking multiple selected elements at once

### DIFF
--- a/src/optiverse/objects/base_obj.py
+++ b/src/optiverse/objects/base_obj.py
@@ -449,7 +449,17 @@ class BaseObj(QtWidgets.QGraphicsObject):
         if a == act_edit:
             self.open_editor()
         elif a == act_lock and act_lock is not None:
-            self.set_locked(act_lock.isChecked())
+            new_locked = act_lock.isChecked()
+            scene = self.scene()
+            selected = scene.selectedItems() if scene else []
+            peers = [
+                item for item in selected
+                if item is not self and hasattr(item, "set_locked")
+            ]
+            if peers:
+                self._batch_set_locked([self] + peers, new_locked)
+            else:
+                self.set_locked(new_locked)
         elif a == act_delete and act_delete is not None:
             if not self._locked:
                 self.requestDelete.emit(self)
@@ -458,6 +468,40 @@ class BaseObj(QtWidgets.QGraphicsObject):
             self._handle_z_order_action(
                 a, act_bring_to_front, act_bring_forward, act_send_backward, act_send_to_back
             )
+
+    def _batch_set_locked(self, items: list, new_locked: bool) -> None:
+        """Lock/unlock multiple items as a single undoable batch via the layer model."""
+        scene = self.scene()
+        if not scene or not scene.views():
+            return
+        window = scene.views()[0].window()
+        layer_state = getattr(window, "layer_state", None)
+        undo_stack = getattr(window, "undo_stack", None)
+        if not layer_state:
+            for item in items:
+                item.set_locked(new_locked)
+            return
+
+        from ..core.undo_commands import BatchCommand, ToggleLockCommand
+
+        layer_panel = getattr(window, "layer_panel", None)
+        model = layer_panel.model if layer_panel else None
+        apply_fn = model._apply_effective_locked if model else lambda n: None
+
+        cmds = []
+        for item in items:
+            if not hasattr(item, "item_uuid"):
+                continue
+            node = layer_state.get_node(item.item_uuid)
+            if node and node.locked != new_locked:
+                cmds.append(ToggleLockCommand(node, node.locked, new_locked, apply_fn))
+        if not cmds:
+            return
+        batch = BatchCommand(cmds) if len(cmds) > 1 else cmds[0]
+        if undo_stack:
+            undo_stack.push(batch)
+        else:
+            batch.execute()
 
     def _handle_z_order_action(
         self,

--- a/src/optiverse/objects/generic/component_item.py
+++ b/src/optiverse/objects/generic/component_item.py
@@ -557,7 +557,17 @@ class ComponentItem(BaseObj):
         elif a == act_apply_all:
             self._apply_properties_to_all()
         elif a == act_lock and act_lock is not None:
-            self.set_locked(act_lock.isChecked())
+            new_locked = act_lock.isChecked()
+            scene = self.scene()
+            selected = scene.selectedItems() if scene else []
+            peers = [
+                item for item in selected
+                if item is not self and hasattr(item, "set_locked")
+            ]
+            if peers:
+                self._batch_set_locked([self] + peers, new_locked)
+            else:
+                self.set_locked(new_locked)
         elif a == act_delete and act_delete is not None:
             if not self._locked:
                 self.requestDelete.emit(self)

--- a/src/optiverse/ui/delegates/layer_item_delegate.py
+++ b/src/optiverse/ui/delegates/layer_item_delegate.py
@@ -123,7 +123,23 @@ class LayerItemDelegate(QtWidgets.QStyledItemDelegate):
         # Lock icon - toggle on press, consume double-click
         if lock_rect.contains(pos):
             if is_press:
-                model.setData(index, not bool(index.data(LOCKED_ROLE)), int(LOCKED_ROLE))
+                new_locked = not bool(index.data(LOCKED_ROLE))
+                view = option.widget
+                sm = (
+                    view.selectionModel()
+                    if isinstance(view, QtWidgets.QAbstractItemView)
+                    else None
+                )
+                selected = sm.selectedRows(0) if sm else []
+                if len(selected) > 1 and index in selected:
+                    from ..models.layer_item_model import LayerItemModel
+
+                    if isinstance(model, LayerItemModel):
+                        model.toggle_locked_for_indexes(selected, new_locked)
+                    else:
+                        model.setData(index, new_locked, int(LOCKED_ROLE))
+                else:
+                    model.setData(index, new_locked, int(LOCKED_ROLE))
             return True
 
         # Folder icon - consume all clicks (no action, prevents edit)

--- a/src/optiverse/ui/models/layer_item_model.py
+++ b/src/optiverse/ui/models/layer_item_model.py
@@ -281,6 +281,32 @@ class LayerItemModel(QtCore.QAbstractItemModel):
 
         return False
 
+    def toggle_locked_for_indexes(
+        self, indexes: list[QtCore.QModelIndex], new_locked: bool
+    ) -> None:
+        """Toggle lock on multiple layer nodes as a single undoable batch."""
+        if not self._scene or not self._layer_state:
+            return
+        cmds: list[Command] = []
+        affected: list[QtCore.QModelIndex] = []
+        for idx in indexes:
+            node = self._node_from_index(idx)
+            if not node or node.locked == new_locked:
+                continue
+            cmds.append(
+                ToggleLockCommand(node, node.locked, new_locked, self._apply_effective_locked)
+            )
+            affected.append(idx)
+        if not cmds:
+            return
+        batch = BatchCommand(cmds) if len(cmds) > 1 else cmds[0]
+        if self._undo_stack:
+            self._undo_stack.push(batch)
+        else:
+            batch.execute()
+        for idx in affected:
+            self.dataChanged.emit(idx, idx, [int(LOCKED_ROLE)])
+
     def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlag:
         if not index.isValid():
             return QtCore.Qt.ItemFlag.ItemIsDropEnabled

--- a/src/optiverse/ui/widgets/layer_panel.py
+++ b/src/optiverse/ui/widgets/layer_panel.py
@@ -476,6 +476,14 @@ class LayerPanel(QtWidgets.QWidget):
             menu.exec(vp.mapToGlobal(pos))
 
     def _toggle_role(self, idx: QtCore.QModelIndex, role: int) -> None:
-        current = bool(idx.data(role))
-        self._model.setData(idx, not current, role)
+        from ..models.layer_item_model import LOCKED_ROLE
+
+        new_value = not bool(idx.data(role))
+        sm = self._tree.selectionModel()
+        selected = sm.selectedRows(0) if sm else []
+
+        if role == int(LOCKED_ROLE) and len(selected) > 1 and idx in selected:
+            self._model.toggle_locked_for_indexes(selected, new_value)
+        else:
+            self._model.setData(idx, new_value, role)
         self.refresh()


### PR DESCRIPTION
When multiple elements are selected, clicking the lock icon or using the context menu "Toggle Lock" now locks/unlocks all selected items as a single undoable batch operation.