### PR TITLE
Increase default PDF export DPI to 600 and raise max to 1200

### DIFF
--- a/src/optiverse/core/preferences.py
+++ b/src/optiverse/core/preferences.py
@@ -41,7 +41,7 @@ clone_offset_y_mm: float = 20.0
 # ── Export Defaults ──────────────────────────────────────────────────
 
 default_png_scale: float = 4.0
-default_pdf_dpi: int = 300
+default_pdf_dpi: int = 600
 export_margin_mm: int = 20
 
 
@@ -70,5 +70,5 @@ def load_from_settings(s: SettingsService) -> None:
     _self.clone_offset_y_mm = s.get_value("canvas/clone_offset_y_mm", 20.0, float)
 
     _self.default_png_scale = s.get_value("export/default_png_scale", 4.0, float)
-    _self.default_pdf_dpi = s.get_value("export/default_pdf_dpi", 300, int)
+    _self.default_pdf_dpi = s.get_value("export/default_pdf_dpi", 600, int)
     _self.export_margin_mm = s.get_value("export/export_margin_mm", 20, int)

--- a/src/optiverse/ui/controllers/file_controller.py
+++ b/src/optiverse/ui/controllers/file_controller.py
@@ -605,7 +605,7 @@ class FileController(QtCore.QObject):
                 "PDF resolution (DPI):",
                 value=self._default_pdf_dpi(),
                 min=72,
-                max=600,
+                max=1200,
                 step=50,
             )
             if not ok:

--- a/src/optiverse/ui/views/settings_dialog.py
+++ b/src/optiverse/ui/views/settings_dialog.py
@@ -342,7 +342,7 @@ class SettingsDialog(QtWidgets.QDialog):
         grp_pdf = QtWidgets.QGroupBox("PDF Export")
         form_pdf = QtWidgets.QFormLayout(grp_pdf)
         self._spin_pdf_dpi = QtWidgets.QSpinBox()
-        self._spin_pdf_dpi.setRange(72, 600)
+        self._spin_pdf_dpi.setRange(72, 1200)
         self._spin_pdf_dpi.setSingleStep(50)
         self._spin_pdf_dpi.setSuffix(" DPI")
         form_pdf.addRow("Default DPI:", self._spin_pdf_dpi)
@@ -492,7 +492,7 @@ class SettingsDialog(QtWidgets.QDialog):
         self._spin_png_scale.setValue(
             s.get_value("export/default_png_scale", 4.0, float)
         )
-        self._spin_pdf_dpi.setValue(s.get_value("export/default_pdf_dpi", 300, int))
+        self._spin_pdf_dpi.setValue(s.get_value("export/default_pdf_dpi", 600, int))
         self._spin_export_margin.setValue(
             s.get_value("export/export_margin_mm", 20, int)
         )


### PR DESCRIPTION
## Summary

- **Default PDF DPI raised from 300 to 600** across preferences, settings dialog, and file controller for sharper publication-quality exports.
- **Max PDF DPI raised from 600 to 1200** in both the export dialog and the settings spinner to give users more headroom.

## Changes

| File | Change |
|------|--------|
| `core/preferences.py` | Default `default_pdf_dpi` 300 → 600 |
| `ui/views/settings_dialog.py` | Spinner range max 600 → 1200, default 300 → 600 |
| `ui/controllers/file_controller.py` | Export dialog max 600 → 1200 |

## Test plan

- [ ] Open Preferences → Export Defaults and verify the PDF DPI spinner shows 600 and allows values up to 1200
- [ ] Export a PDF without changing settings and confirm it renders at 600 DPI
- [ ] Export a PDF at 1200 DPI and confirm it produces a valid, high-resolution file

Made with [Cursor](https://cursor.com)