### PR TITLE
feat: implement 6 UI enhancements (#78, #79, #80, #89, #90, #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Optiverse will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Live cursor coordinates** (#78): Status bar displays real-time X/Y scene coordinates (mm) as the cursor moves over the canvas
+- **Dynamic scale bar units** (#79): Scale bar automatically switches between mm, µm, and nm at high zoom levels, with a dynamically sized bar representing a clean round number
+- **Arrow key nudging** (#89): Move selected items with arrow keys (0.1 mm step) or Shift+Arrow (1.0 mm step); both step sizes are configurable in Preferences → Canvas & Editing
+- **Configurable ruler label positioning** (#90): Ruler labels can be placed Above, Below, Left, or Right relative to the segment via the Edit dialog; setting is serialized and fully undoable
+- **Cross-instance copy/paste** (#34): Items copied in one Optiverse window can be pasted into another via the system clipboard (uses custom MIME type for serialization)
+
+### Changed
+
+- **Zoom-invariant ruler rendering** (#80): Ruler endpoint bars and labels now maintain constant screen size regardless of zoom level, matching the existing cosmetic-pen line behavior
+
 ## [0.3.4] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Live cursor coordinates** (#78): Status bar displays real-time X/Y scene coordinates (mm) as the cursor moves over the canvas
+- **Live cursor coordinates** (#78): Status bar displays real-time X/Y scene coordinates as the cursor moves over the canvas, with units (mm, µm, nm) adapting automatically to the current zoom level
 - **Dynamic scale bar units** (#79): Scale bar automatically switches between mm, µm, and nm at high zoom levels, with a dynamically sized bar representing a clean round number
 - **Arrow key nudging** (#89): Move selected items with arrow keys (0.1 mm step) or Shift+Arrow (1.0 mm step); both step sizes are configurable in Preferences → Canvas & Editing
 - **Configurable ruler label positioning** (#90): Ruler labels can be placed Above, Below, Left, or Right relative to the segment via the Edit dialog; setting is serialized and fully undoable
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Zoom-invariant ruler rendering** (#80): Ruler endpoint bars and labels now maintain constant screen size regardless of zoom level, matching the existing cosmetic-pen line behavior
+- **Zoom-invariant ruler rendering** (#80): Ruler endpoint bars, labels, selection bounds, and hit-test areas now maintain constant screen size regardless of zoom level, matching the existing cosmetic-pen line behavior
 
 ## [0.3.4] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ python -m optiverse.app.main
 | Copy | `Ctrl+C` | `⌘C` |
 | Paste | `Ctrl+V` | `⌘V` |
 | Delete | `Delete` / `Backspace` | `Delete` / `⌫` |
+| Nudge selected items | `Arrow keys` | `Arrow keys` |
+| Nudge (large step) | `Shift + Arrow keys` | `⇧ + Arrow keys` |
 | Preferences | `Ctrl+,` | `⌘,` |
 | **View** | | |
 | Zoom In | `Ctrl++` | `⌘+` |

--- a/src/optiverse/core/preferences.py
+++ b/src/optiverse/core/preferences.py
@@ -37,6 +37,8 @@ wheel_rotation_deg_per_step: float = 2.0
 max_raytracing_events: int = 80
 clone_offset_x_mm: float = 20.0
 clone_offset_y_mm: float = 20.0
+nudge_small_mm: float = 0.1
+nudge_large_mm: float = 1.0
 
 # ── Export Defaults ──────────────────────────────────────────────────
 
@@ -68,6 +70,8 @@ def load_from_settings(s: SettingsService) -> None:
     _self.max_raytracing_events = s.get_value("canvas/max_raytracing_events", 80, int)
     _self.clone_offset_x_mm = s.get_value("canvas/clone_offset_x_mm", 20.0, float)
     _self.clone_offset_y_mm = s.get_value("canvas/clone_offset_y_mm", 20.0, float)
+    _self.nudge_small_mm = s.get_value("canvas/nudge_small_mm", 0.1, float)
+    _self.nudge_large_mm = s.get_value("canvas/nudge_large_mm", 1.0, float)
 
     _self.default_png_scale = s.get_value("export/default_png_scale", 4.0, float)
     _self.default_pdf_dpi = s.get_value("export/default_pdf_dpi", 300, int)

--- a/src/optiverse/objects/annotations/ruler_item.py
+++ b/src/optiverse/objects/annotations/ruler_item.py
@@ -103,6 +103,21 @@ class RulerItem(QtWidgets.QGraphicsObject):
         self._grab: int | None = None  # index of grabbed point, or None
         self._initial_points: list[QtCore.QPointF] | None = None  # Track for undo
 
+        # Cached inverse view scale for geometry invalidation
+        self._cached_inv_scale: float = 1.0
+
+    # ========== View Scale ==========
+
+    def _view_scale(self) -> float:
+        """Return the current view zoom scale (px per scene-unit)."""
+        scene = self.scene()
+        if scene:
+            views = scene.views()
+            if views:
+                t = views[0].transform()
+                return math.hypot(t.m11(), t.m21()) or 1.0
+        return 1.0
+
     # ========== Locking ==========
 
     def is_locked(self) -> bool:
@@ -230,14 +245,15 @@ class RulerItem(QtWidgets.QGraphicsObject):
             last_end.y() + perp_y * perp_off + along_y * along_off,
         )
 
-    def _get_label_bounding_rect(self, pos: QtCore.QPointF, text: str) -> QtCore.QRectF:
+    def _get_label_bounding_rect(
+        self, pos: QtCore.QPointF, text: str, inv_scale: float = 1.0
+    ) -> QtCore.QRectF:
         """Calculate bounding rectangle for a label (for hit testing)."""
         fm = QtGui.QFontMetrics(QtGui.QFont())
-        w = fm.horizontalAdvance(text) + 12
-        h = fm.height() + 6
+        w = (fm.horizontalAdvance(text) + 12) * inv_scale
+        h = (fm.height() + 6) * inv_scale
 
-        # Use larger box to account for rotation
-        padding = RULER_BAR_HEIGHT / 2.0 + RULER_LABEL_PADDING
+        padding = (RULER_BAR_HEIGHT / 2.0 + RULER_LABEL_PADDING) * inv_scale
         max_dim = max(w, h) + padding
         return QtCore.QRectF(
             pos.x() - max_dim / 2.0, pos.y() - max_dim / 2.0 - padding, max_dim, max_dim
@@ -254,7 +270,8 @@ class RulerItem(QtWidgets.QGraphicsObject):
         min_y = min(p.y() for p in self._points)
         max_y = max(p.y() for p in self._points)
         rect = QtCore.QRectF(min_x, min_y, max_x - min_x, max_y - min_y)
-        pad = max(RULER_BOUNDING_PAD_PX, RULER_BAR_HEIGHT * 1.5)
+        inv = 1.0 / self._view_scale()
+        pad = max(RULER_BOUNDING_PAD_PX, RULER_BAR_HEIGHT * 1.5) * inv
         return rect.adjusted(-pad, -pad, pad, pad)
 
     def shape(self) -> QtGui.QPainterPath:
@@ -262,34 +279,33 @@ class RulerItem(QtWidgets.QGraphicsObject):
         if len(self._points) < 2:
             return path
 
+        inv = 1.0 / self._view_scale()
+
         # Add the line path with stroke width for hit testing
         line_path = QtGui.QPainterPath()
         line_path.moveTo(self._points[0])
         for i in range(1, len(self._points)):
             line_path.lineTo(self._points[i])
         stroker = QtGui.QPainterPathStroker()
-        stroker.setWidth(max(RULER_MIN_STROKE_WIDTH_PX, RULER_BAR_HEIGHT))
+        stroker.setWidth(max(RULER_MIN_STROKE_WIDTH_PX, RULER_BAR_HEIGHT) * inv)
         path.addPath(stroker.createStroke(line_path))
 
         # Add label areas for hit testing
         segment_lengths, total_length = self._compute_segment_data()
 
         if len(self._points) > 2:
-            # Multi-segment: add per-segment labels
             for i in range(len(self._points) - 1):
                 seg_mid = (self._points[i] + self._points[i + 1]) * 0.5
                 seg_txt = f"{segment_lengths[i]:.1f} mm"
-                path.addRect(self._get_label_bounding_rect(seg_mid, seg_txt))
+                path.addRect(self._get_label_bounding_rect(seg_mid, seg_txt, inv))
 
-            # Add total label
-            total_pos = self._compute_total_label_position()
+            total_pos = self._compute_total_label_position(inv)
             total_txt = f"Total: {total_length:.1f} mm"
-            path.addRect(self._get_label_bounding_rect(total_pos, total_txt))
+            path.addRect(self._get_label_bounding_rect(total_pos, total_txt, inv))
         else:
-            # Single segment: add centered label
             mid = (self._points[0] + self._points[1]) * 0.5
             total_txt = f"{total_length:.1f} mm"
-            path.addRect(self._get_label_bounding_rect(mid, total_txt))
+            path.addRect(self._get_label_bounding_rect(mid, total_txt, inv))
 
         return path
 
@@ -401,6 +417,10 @@ class RulerItem(QtWidgets.QGraphicsObject):
         view_scale = math.hypot(t.m11(), t.m21()) or 1.0
         inv_scale = 1.0 / view_scale
 
+        if abs(inv_scale - self._cached_inv_scale) > 1e-6 * inv_scale:
+            self._cached_inv_scale = inv_scale
+            self.prepareGeometryChange()
+
         is_selected = self.isSelected()
 
         dark_mode = is_dark_mode()
@@ -483,11 +503,12 @@ class RulerItem(QtWidgets.QGraphicsObject):
 
     def _nearest_point(self, pos: QtCore.QPointF) -> int | None:
         """Check if pos is near any point, return index if found."""
+        hit_radius = RULER_HIT_RADIUS_PX / self._view_scale()
         min_dist = float("inf")
         nearest_idx = None
         for i, point in enumerate(self._points):
             dist = QtCore.QLineF(pos, point).length()
-            if dist <= RULER_HIT_RADIUS_PX and dist < min_dist:
+            if dist <= hit_radius and dist < min_dist:
                 min_dist = dist
                 nearest_idx = i
         return nearest_idx

--- a/src/optiverse/objects/annotations/ruler_item.py
+++ b/src/optiverse/objects/annotations/ruler_item.py
@@ -397,7 +397,8 @@ class RulerItem(QtWidgets.QGraphicsObject):
         if len(self._points) < 2:
             return
 
-        view_scale = abs(painter.deviceTransform().m11()) or 1.0
+        t = painter.transform()
+        view_scale = math.hypot(t.m11(), t.m21()) or 1.0
         inv_scale = 1.0 / view_scale
 
         is_selected = self.isSelected()

--- a/src/optiverse/objects/annotations/ruler_item.py
+++ b/src/optiverse/objects/annotations/ruler_item.py
@@ -96,6 +96,9 @@ class RulerItem(QtWidgets.QGraphicsObject):
         self._locked = False
         self._group_drag_override = False
 
+        # Label position: "above" (default), "below", "left", or "right"
+        self._label_position: str = "above"
+
         # Interaction state
         self._grab: int | None = None  # index of grabbed point, or None
         self._initial_points: list[QtCore.QPointF] | None = None  # Track for undo
@@ -205,7 +208,7 @@ class RulerItem(QtWidgets.QGraphicsObject):
             total_length += seg_len
         return segment_lengths, total_length
 
-    def _compute_total_label_position(self) -> QtCore.QPointF:
+    def _compute_total_label_position(self, inv_scale: float = 1.0) -> QtCore.QPointF:
         """Compute position for total length label (multi-segment rulers)."""
         last_start = self._points[-2]
         last_end = self._points[-1]
@@ -213,17 +216,18 @@ class RulerItem(QtWidgets.QGraphicsObject):
         dy = last_end.y() - last_start.y()
         length = math.hypot(dx, dy) or 1.0
 
-        # Perpendicular and along-segment unit vectors
         perp_x, perp_y = -dy / length, dx / length
         along_x, along_y = dx / length, dy / length
 
+        perp_off = RULER_TOTAL_LABEL_PERP_OFFSET * inv_scale
+        along_off = RULER_TOTAL_LABEL_ALONG_OFFSET * inv_scale
+
+        if self._label_position == "below":
+            perp_off = -perp_off
+
         return QtCore.QPointF(
-            last_end.x()
-            + perp_x * RULER_TOTAL_LABEL_PERP_OFFSET
-            + along_x * RULER_TOTAL_LABEL_ALONG_OFFSET,
-            last_end.y()
-            + perp_y * RULER_TOTAL_LABEL_PERP_OFFSET
-            + along_y * RULER_TOTAL_LABEL_ALONG_OFFSET,
+            last_end.x() + perp_x * perp_off + along_x * along_off,
+            last_end.y() + perp_y * perp_off + along_y * along_off,
         )
 
     def _get_label_bounding_rect(self, pos: QtCore.QPointF, text: str) -> QtCore.QRectF:
@@ -300,11 +304,12 @@ class RulerItem(QtWidgets.QGraphicsObject):
         perp_x: float,
         perp_y: float,
         color: QtGui.QColor,
+        inv_scale: float = 1.0,
     ) -> None:
         """Draw a bar perpendicular to the line at center point."""
         cx, cy = center.x(), center.y()
-        hw = RULER_BAR_WIDTH / 2.0  # half-width along direction
-        hh = RULER_BAR_HEIGHT / 2.0  # half-height along perpendicular
+        hw = RULER_BAR_WIDTH / 2.0 * inv_scale
+        hh = RULER_BAR_HEIGHT / 2.0 * inv_scale
 
         pts = [
             QtCore.QPointF(cx + (-hw * dir_x + -hh * perp_x), cy + (-hw * dir_y + -hh * perp_y)),
@@ -314,7 +319,9 @@ class RulerItem(QtWidgets.QGraphicsObject):
         ]
 
         painter.save()
-        painter.setPen(QtGui.QPen(color, 1))
+        pen = QtGui.QPen(color, 1)
+        pen.setCosmetic(True)
+        painter.setPen(pen)
         painter.setBrush(color)
         painter.drawPolygon(QtGui.QPolygonF(pts))
         painter.restore()
@@ -328,9 +335,9 @@ class RulerItem(QtWidgets.QGraphicsObject):
         seg_dy: float,
         is_selected: bool,
         dark_mode: bool = False,
+        inv_scale: float = 1.0,
     ) -> None:
         """Draw a text label at the given position with proper rotation."""
-        # Ensure text is always readable (flip direction if needed)
         dx_calc, dy_calc = seg_dx, seg_dy
         if seg_dx < 0:
             dx_calc, dy_calc = -seg_dx, -seg_dy
@@ -339,32 +346,43 @@ class RulerItem(QtWidgets.QGraphicsObject):
         painter.save()
         painter.translate(pos)
         painter.rotate(angle)
-        # Compensate for view's Y-axis inversion
-        painter.scale(1.0, -1.0)
+        painter.scale(inv_scale, -inv_scale)
 
         fm = QtGui.QFontMetrics(painter.font())
         w = fm.horizontalAdvance(text) + 12
         h = fm.height() + 6
-        y_off = -(RULER_BAR_HEIGHT / 2.0 + RULER_LABEL_PADDING + h)
+        bar_hh = RULER_BAR_HEIGHT / 2.0
+        pad = RULER_LABEL_PADDING
 
-        # Background and text colors
+        lp = self._label_position
+        if lp == "below":
+            x_off = -w / 2.0
+            y_off = bar_hh + pad
+        elif lp == "left":
+            x_off = -w - pad
+            y_off = -h / 2.0
+        elif lp == "right":
+            x_off = pad
+            y_off = -h / 2.0
+        else:  # "above" (default)
+            x_off = -w / 2.0
+            y_off = -(bar_hh + pad + h)
+
         if is_selected:
             bg_color = QtGui.QColor(255, 255, 255, RULER_LABEL_BG_ALPHA_SELECTED)
-            text_color = QtGui.QColor(0, 120, 215)  # Selection blue
+            text_color = QtGui.QColor(0, 120, 215)
         elif dark_mode:
-            bg_color = QtGui.QColor(40, 40, 40, RULER_LABEL_BG_ALPHA)  # Dark background
-            text_color = QtGui.QColor(255, 255, 255)  # White text
+            bg_color = QtGui.QColor(40, 40, 40, RULER_LABEL_BG_ALPHA)
+            text_color = QtGui.QColor(255, 255, 255)
         else:
             bg_color = QtGui.QColor(255, 255, 255, RULER_LABEL_BG_ALPHA)
             text_color = QtGui.QColor(20, 20, 20)
 
-        # Draw background
         painter.setPen(QtCore.Qt.PenStyle.NoPen)
         painter.setBrush(bg_color)
-        label_rect = QtCore.QRectF(-w / 2.0, y_off, float(w), float(h))
+        label_rect = QtCore.QRectF(x_off, y_off, float(w), float(h))
         painter.drawRoundedRect(label_rect, RULER_LABEL_CORNER_RADIUS, RULER_LABEL_CORNER_RADIUS)
 
-        # Draw text
         painter.setPen(QtGui.QPen(text_color))
         painter.drawText(label_rect, QtCore.Qt.AlignmentFlag.AlignCenter, text)
 
@@ -379,15 +397,17 @@ class RulerItem(QtWidgets.QGraphicsObject):
         if len(self._points) < 2:
             return
 
+        view_scale = abs(painter.deviceTransform().m11()) or 1.0
+        inv_scale = 1.0 / view_scale
+
         is_selected = self.isSelected()
 
-        # Line appearance based on selection and theme
         dark_mode = is_dark_mode()
         if is_selected:
-            base_color = QtGui.QColor(0, 120, 215)  # Blue for selection
+            base_color = QtGui.QColor(0, 120, 215)
             line_width = RULER_LINE_WIDTH_SELECTED
         elif dark_mode:
-            base_color = QtGui.QColor(255, 255, 255)  # White for dark mode
+            base_color = QtGui.QColor(255, 255, 255)
             line_width = RULER_LINE_WIDTH
         else:
             base_color = QtGui.QColor(30, 30, 30)
@@ -400,16 +420,12 @@ class RulerItem(QtWidgets.QGraphicsObject):
         painter.setPen(base_pen)
         painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
 
-        # Calculate segment data once
         segment_lengths, total_length = self._compute_segment_data()
 
-        # Draw lines between consecutive points
         for i in range(len(self._points) - 1):
             painter.drawLine(self._points[i], self._points[i + 1])
 
-        # Draw bars at all points
         for i in range(len(self._points)):
-            # Determine direction for bar orientation
             if i == 0:
                 dx = self._points[1].x() - self._points[0].x()
                 dy = self._points[1].y() - self._points[0].y()
@@ -417,7 +433,6 @@ class RulerItem(QtWidgets.QGraphicsObject):
                 dx = self._points[-1].x() - self._points[-2].x()
                 dy = self._points[-1].y() - self._points[-2].y()
             else:
-                # Middle point: average direction of adjacent segments
                 dx1 = self._points[i].x() - self._points[i - 1].x()
                 dy1 = self._points[i].y() - self._points[i - 1].y()
                 dx2 = self._points[i + 1].x() - self._points[i].x()
@@ -432,32 +447,36 @@ class RulerItem(QtWidgets.QGraphicsObject):
             if is_selected:
                 bar_color = base_color
             elif dark_mode:
-                bar_color = QtGui.QColor(255, 255, 255)  # White for dark mode
+                bar_color = QtGui.QColor(255, 255, 255)
             else:
                 bar_color = QtGui.QColor(QtCore.Qt.GlobalColor.black)
-            self._draw_bar(painter, self._points[i], dir_x, dir_y, perp_x, perp_y, bar_color)
+            self._draw_bar(
+                painter, self._points[i], dir_x, dir_y, perp_x, perp_y, bar_color, inv_scale
+            )
 
-        # Draw labels
         if len(self._points) > 2:
-            # Multi-segment: show label for each segment
             for i in range(len(self._points) - 1):
                 seg_mid = (self._points[i] + self._points[i + 1]) * 0.5
                 seg_dx = self._points[i + 1].x() - self._points[i].x()
                 seg_dy = self._points[i + 1].y() - self._points[i].y()
                 seg_txt = f"{segment_lengths[i]:.1f} mm"
-                self._draw_label(painter, seg_mid, seg_txt, seg_dx, seg_dy, is_selected, dark_mode)
+                self._draw_label(
+                    painter, seg_mid, seg_txt, seg_dx, seg_dy, is_selected, dark_mode, inv_scale
+                )
 
-            # Total length label
-            total_pos = self._compute_total_label_position()
+            total_pos = self._compute_total_label_position(inv_scale)
             total_txt = f"Total: {total_length:.1f} mm"
-            self._draw_label(painter, total_pos, total_txt, 1.0, 0.0, is_selected, dark_mode)
+            self._draw_label(
+                painter, total_pos, total_txt, 1.0, 0.0, is_selected, dark_mode, inv_scale
+            )
         else:
-            # Single segment: show total distance label
             mid = (self._points[0] + self._points[1]) * 0.5
             total_txt = f"{total_length:.1f} mm"
             seg_dx = self._points[1].x() - self._points[0].x()
             seg_dy = self._points[1].y() - self._points[0].y()
-            self._draw_label(painter, mid, total_txt, seg_dx, seg_dy, is_selected, dark_mode)
+            self._draw_label(
+                painter, mid, total_txt, seg_dx, seg_dy, is_selected, dark_mode, inv_scale
+            )
 
     # ========== Mouse Event Handling ==========
 
@@ -686,6 +705,7 @@ class RulerItem(QtWidgets.QGraphicsObject):
             "points": [[float(p.x()), float(p.y())] for p in self._points],
             "pos": {"x": float(self.pos().x()), "y": float(self.pos().y())},
             "display_name": self.display_name,
+            "label_position": self._label_position,
         }
 
     def apply_state(self, state: dict[str, Any]) -> None:
@@ -698,6 +718,8 @@ class RulerItem(QtWidgets.QGraphicsObject):
             self.setPos(QtCore.QPointF(float(state["pos"]["x"]), float(state["pos"]["y"])))
         if "display_name" in state:
             self.display_name = state["display_name"]
+        if "label_position" in state:
+            self._label_position = state["label_position"]
 
     @staticmethod
     def _segment_length_angle_deg(
@@ -746,8 +768,21 @@ class RulerItem(QtWidgets.QGraphicsObject):
 
         name_edit.textChanged.connect(lambda _t: update_display_name())
 
+        _LABEL_POSITIONS = ["Above", "Below", "Left", "Right"]
+        label_pos_combo = QtWidgets.QComboBox()
+        label_pos_combo.addItems(_LABEL_POSITIONS)
+        label_pos_combo.setCurrentText(self._label_position.capitalize())
+
+        def update_label_pos(text: str) -> None:
+            self._label_position = text.lower()
+            self.prepareGeometryChange()
+            self.update()
+
+        label_pos_combo.currentTextChanged.connect(update_label_pos)
+
         form = QtWidgets.QFormLayout()
         form.addRow("Display name", name_edit)
+        form.addRow("Label position", label_pos_combo)
 
         segment_spins: list[tuple[SmartDoubleSpinBox, SmartDoubleSpinBox]] = []
         for i in range(len(self._points) - 1):
@@ -819,6 +854,7 @@ class RulerItem(QtWidgets.QGraphicsObject):
         ]
         new_ruler = RulerItem(points=new_points, item_uuid=str(uuid.uuid4()))
         new_ruler.setZValue(self.zValue())
+        new_ruler._label_position = self._label_position
 
         return new_ruler
 
@@ -834,6 +870,8 @@ class RulerItem(QtWidgets.QGraphicsObject):
         }
         if self._locked:
             d["locked"] = True
+        if self._label_position != "above":
+            d["label_position"] = self._label_position
         return d
 
     @staticmethod
@@ -855,5 +893,7 @@ class RulerItem(QtWidgets.QGraphicsObject):
             item.setZValue(float(d["z_value"]))
         if d.get("locked"):
             item.set_locked(True)
+        if "label_position" in d:
+            item._label_position = d["label_position"]
 
         return item

--- a/src/optiverse/objects/views/graphics_view.py
+++ b/src/optiverse/objects/views/graphics_view.py
@@ -42,6 +42,7 @@ except ImportError:
 class GraphicsView(QtWidgets.QGraphicsView):
     zoomChanged = QtCore.pyqtSignal()
     cursorScenePosChanged = QtCore.pyqtSignal(QtCore.QPointF)
+    nudgeRequested = QtCore.pyqtSignal(int, bool)  # key code, shift held
     # Signal emitted when a component is dropped (dict, QPointF)
     componentDropped = QtCore.pyqtSignal(dict, QtCore.QPointF)
 
@@ -905,6 +906,11 @@ class GraphicsView(QtWidgets.QGraphicsView):
         if e is not None:
             self.cursorScenePosChanged.emit(self.mapToScene(e.pos()))
 
+    _ARROW_KEYS = frozenset({
+        QtCore.Qt.Key.Key_Left, QtCore.Qt.Key.Key_Right,
+        QtCore.Qt.Key.Key_Up, QtCore.Qt.Key.Key_Down,
+    })
+
     # ----- Pan Controls (Phase 3.1: Space + Middle Button) -----
     def keyPressEvent(self, e: QtGui.QKeyEvent | None):
         """Handle key press for pan mode (Space key).
@@ -914,6 +920,17 @@ class GraphicsView(QtWidgets.QGraphicsView):
         """
         if e is None:
             return
+
+        # Arrow key nudging — must be checked before the modifier guard
+        # so that Shift+Arrow (large nudge) also works.
+        if e.key() in self._ARROW_KEYS:
+            scene = self.scene()
+            if scene is not None and scene.focusItem() is None and scene.selectedItems():
+                shift = bool(e.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier)
+                self.nudgeRequested.emit(e.key(), shift)
+                e.accept()
+                return
+
         # Don't handle key events with modifiers - let them propagate for shortcuts
         if e.modifiers() not in (
             QtCore.Qt.KeyboardModifier.NoModifier,

--- a/src/optiverse/objects/views/graphics_view.py
+++ b/src/optiverse/objects/views/graphics_view.py
@@ -41,6 +41,7 @@ except ImportError:
 
 class GraphicsView(QtWidgets.QGraphicsView):
     zoomChanged = QtCore.pyqtSignal()
+    cursorScenePosChanged = QtCore.pyqtSignal(QtCore.QPointF)
     # Signal emitted when a component is dropped (dict, QPointF)
     componentDropped = QtCore.pyqtSignal(dict, QtCore.QPointF)
 
@@ -104,6 +105,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
                 viewport.setAttribute(QtCore.Qt.WidgetAttribute.WA_AcceptTouchEvents, True)
                 viewport.grabGesture(QtCore.Qt.GestureType.PinchGesture)
                 viewport.grabGesture(QtCore.Qt.GestureType.PanGesture)
+
+        # Enable mouse tracking for live cursor coordinate display
+        self.setMouseTracking(True)
+        viewport = self.viewport()
+        if viewport is not None:
+            viewport.setMouseTracking(True)
 
         # scale bar prefs
         self._show_scale_bar = True
@@ -170,6 +177,40 @@ class GraphicsView(QtWidgets.QGraphicsView):
         viewport = self.viewport()
         if viewport is not None:
             viewport.update()
+
+    _NICE_STEPS = [1, 2, 5]
+    _SB_MIN_PX = 40
+    _SB_MAX_PX = 160
+
+    def _nice_scale_bar(self, px_per_mm: float) -> tuple[float, float, str]:
+        """Pick a nice round value for the scale bar at the current zoom.
+
+        Returns (bar_pixel_width, display_value, unit_string).
+        """
+        import math
+
+        mm_per_px = 1.0 / px_per_mm
+        # mm range that fits _SB_MIN_PX .. _SB_MAX_PX
+        mm_min = self._SB_MIN_PX * mm_per_px
+        mm_max = self._SB_MAX_PX * mm_per_px
+
+        # Walk powers of 10 and pick the largest nice value that fits
+        exp = math.floor(math.log10(max(mm_min, 1e-30)))
+        best_mm = mm_min
+        for e in range(exp - 1, exp + 3):
+            for s in self._NICE_STEPS:
+                val = s * (10.0 ** e)
+                if mm_min <= val <= mm_max:
+                    best_mm = val
+
+        bar_px = best_mm * px_per_mm
+
+        if best_mm >= 1.0:
+            return bar_px, best_mm, "mm"
+        elif best_mm >= 1e-3:
+            return bar_px, best_mm * 1e3, "\u00b5m"
+        else:
+            return bar_px, best_mm * 1e6, "nm"
 
     def _restore_drag_state(self):
         """Restore transformation anchor and reset mouse tracking after drag operations."""
@@ -577,18 +618,26 @@ class GraphicsView(QtWidgets.QGraphicsView):
         if viewport is None:
             return
         vsize = viewport.size()
-        box_w = self._sb_len_px + 70
+
+        px_per_mm = max(1e-12, self.transform().m11())
+        bar_px, display_val, unit = self._nice_scale_bar(px_per_mm)
+
+        # Format label: drop trailing zeros for clean display
+        if display_val == int(display_val):
+            label = f"{int(display_val)} {unit}"
+        else:
+            label = f"{display_val:g} {unit}"
+
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
+        painter.setFont(self._sb_font)
+        fm = QtGui.QFontMetrics(self._sb_font)
+        label_w = fm.horizontalAdvance(label)
+
+        box_w = int(bar_px) + label_w + 36
         box_h = self._sb_height_px + 22
         x0 = self._sb_margin_px
         y0 = vsize.height() - box_h - self._sb_margin_px
 
-        # pixels per unit (assume mm world for now) = m11
-        px_per_mm = max(1e-12, self.transform().m11())
-        mm_value = self._sb_len_px / px_per_mm
-
-        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
-
-        # Scale bar colors based on dark mode
         if self._dark_mode:
             painter.setPen(QtGui.QPen(QtGui.QColor(100, 100, 100, 90)))
             painter.setBrush(QtGui.QColor(40, 40, 45, 200))
@@ -596,7 +645,7 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
             painter.setPen(QtCore.Qt.PenStyle.NoPen)
             painter.setBrush(QtGui.QColor(200, 200, 200))
-            painter.drawRect(x0 + 12, y0 + 11, self._sb_len_px, self._sb_height_px)
+            painter.drawRect(x0 + 12, y0 + 11, int(bar_px), self._sb_height_px)
 
             painter.setPen(QtGui.QColor(220, 220, 220))
         else:
@@ -606,13 +655,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
 
             painter.setPen(QtCore.Qt.PenStyle.NoPen)
             painter.setBrush(QtGui.QColor(30, 30, 30))
-            painter.drawRect(x0 + 12, y0 + 11, self._sb_len_px, self._sb_height_px)
+            painter.drawRect(x0 + 12, y0 + 11, int(bar_px), self._sb_height_px)
 
             painter.setPen(QtGui.QColor(20, 20, 20))
 
         painter.setFont(self._sb_font)
-        label = f"{mm_value:.1f} mm"
-        painter.drawText(x0 + 12 + self._sb_len_px + 8, y0 + 11 + self._sb_height_px, label)
+        painter.drawText(x0 + 12 + int(bar_px) + 8, y0 + 11 + self._sb_height_px, label)
 
         painter.restore()
 
@@ -850,6 +898,12 @@ class GraphicsView(QtWidgets.QGraphicsView):
         # If we get here without accepting, restore state and ignore
         self._restore_drag_state()
         e.ignore()
+
+    # ----- Cursor Coordinate Tracking -----
+    def mouseMoveEvent(self, e: QtGui.QMouseEvent | None):
+        super().mouseMoveEvent(e)
+        if e is not None:
+            self.cursorScenePosChanged.emit(self.mapToScene(e.pos()))
 
     # ----- Pan Controls (Phase 3.1: Space + Middle Button) -----
     def keyPressEvent(self, e: QtGui.QKeyEvent | None):

--- a/src/optiverse/ui/builders/action_builder.py
+++ b/src/optiverse/ui/builders/action_builder.py
@@ -522,9 +522,14 @@ class ActionBuilder:
         mCollab.addAction(w.act_collaborate)
         mCollab.addAction(w.act_disconnect)
 
+        # Add cursor coordinate display to status bar
+        w.coord_label = QtWidgets.QLabel("X: --  Y: -- mm")
+        status_bar = w.statusBar()
+        if status_bar is not None:
+            status_bar.addPermanentWidget(w.coord_label)
+
         # Add collaboration status to status bar
         w.collab_status_label = QtWidgets.QLabel("Not connected")
-        status_bar = w.statusBar()
         if status_bar is not None:
             status_bar.addPermanentWidget(w.collab_status_label)
 

--- a/src/optiverse/ui/controllers/component_operations.py
+++ b/src/optiverse/ui/controllers/component_operations.py
@@ -380,7 +380,7 @@ class ComponentOperationsHandler:
                 new_item: object | None = None
                 if item_type == "ruler":
                     new_item = RulerItem.from_dict(d)
-                elif item_type == "text_note":
+                elif item_type in ("text_note", "text"):
                     new_item = TextNoteItem.from_dict(d)
                 elif item_type == "rectangle":
                     new_item = RectangleItem.from_dict(d)

--- a/src/optiverse/ui/controllers/component_operations.py
+++ b/src/optiverse/ui/controllers/component_operations.py
@@ -171,11 +171,14 @@ class ComponentOperationsHandler:
 
         self._schedule_retrace()
 
+    _MIME_TYPE = "application/x-optiverse-items"
+
     def copy_selected(self):
         """Copy selected items to clipboard.
 
         When a ComponentItem with an autolabel is copied, the label is
-        automatically included so paste can re-link it.
+        automatically included so paste can re-link it.  Items are also
+        serialized to the system clipboard for cross-instance paste.
         """
         from ...objects import BaseObj, RectangleItem
         from ...objects.annotations import RulerItem, TextNoteItem
@@ -203,12 +206,46 @@ class ComponentOperationsHandler:
         self._set_paste_enabled(len(self._clipboard) > 0)
 
         if len(self._clipboard) > 0:
+            self._copy_to_system_clipboard()
             self.log_service.info(
                 f"Copied {len(self._clipboard)} item(s) to clipboard", LogCategory.COPY_PASTE
             )
 
+    def _copy_to_system_clipboard(self) -> None:
+        """Serialize clipboard items to the system clipboard for cross-instance paste."""
+        import json
+
+        from PyQt6.QtGui import QGuiApplication
+
+        from ...objects import BaseObj, RectangleItem
+        from ...objects.annotations import RulerItem, TextNoteItem
+        from ...objects.type_registry import serialize_item
+
+        items_data: list[dict] = []
+        for item in self._clipboard:
+            try:
+                if isinstance(item, (RulerItem, TextNoteItem, RectangleItem)):
+                    items_data.append(item.to_dict())
+                elif isinstance(item, BaseObj):
+                    items_data.append(serialize_item(item))
+            except Exception:
+                pass
+
+        if not items_data:
+            return
+
+        payload = json.dumps({"optiverse_clipboard": items_data})
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is not None:
+            mime = QtCore.QMimeData()
+            mime.setData(self._MIME_TYPE, payload.encode("utf-8"))
+            clipboard.setMimeData(mime)
+
     def paste_items(self, target_pos: QtCore.QPointF | None = None):
         """Paste items from clipboard using clone() method.
+
+        If the in-memory clipboard is empty, attempts to read serialized
+        items from the system clipboard (cross-instance paste).
 
         Args:
             target_pos: Optional target position in scene coordinates.
@@ -219,11 +256,16 @@ class ComponentOperationsHandler:
         from ...objects.annotations import TextNoteItem
         from ...objects.generic.component_item import ComponentItem
 
+        # Try cross-instance paste when local clipboard is empty
         if not self._clipboard:
+            cross_items = self._items_from_system_clipboard()
+            if cross_items:
+                self._paste_deserialized_items(cross_items, target_pos)
+                return
             self.log_service.warning("Cannot paste - clipboard is empty", LogCategory.COPY_PASTE)
             return
 
-        # Calculate offset based on target position or use fixed offset
+        # Same-instance paste via clone()
         if target_pos is not None:
             centroid_x = 0.0
             centroid_y = 0.0
@@ -246,7 +288,6 @@ class ComponentOperationsHandler:
             paste_offset = (preferences.clone_offset_x_mm, preferences.clone_offset_y_mm)
 
         pasted_items = []
-        # Maps old owner UUID -> new cloned ComponentItem (for autolabel re-linking)
         owner_map: dict[str, ComponentItem] = {}
 
         for item in self._clipboard:
@@ -255,7 +296,6 @@ class ComponentOperationsHandler:
                 self._connect_item_signals(cloned_item)
                 pasted_items.append(cloned_item)
 
-                # Track UUID mapping for ComponentItem owners
                 if isinstance(item, ComponentItem):
                     owner_map[item.item_uuid] = cloned_item
 
@@ -267,11 +307,9 @@ class ComponentOperationsHandler:
                     LogCategory.COPY_PASTE,
                 )
 
-        # Re-link cloned autolabels to their new owners
         for cloned in pasted_items:
             if not isinstance(cloned, TextNoteItem):
                 continue
-            # Find the original item this was cloned from
             orig = next(
                 (it for it in self._clipboard
                  if isinstance(it, TextNoteItem) and it.owner_uuid is not None
@@ -300,7 +338,116 @@ class ComponentOperationsHandler:
 
             self._schedule_retrace()
 
+    # ---- Cross-instance helpers ----
+
+    def _items_from_system_clipboard(self) -> list:
+        """Deserialize optiverse items from the system clipboard, if present."""
+        import json
+
+        from PyQt6.QtGui import QGuiApplication
+
+        clipboard = QGuiApplication.clipboard()
+        if clipboard is None:
+            return []
+        mime = clipboard.mimeData()
+        if mime is None or not mime.hasFormat(self._MIME_TYPE):
+            return []
+
+        try:
+            raw = bytes(mime.data(self._MIME_TYPE)).decode("utf-8")
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return []
+
+        item_dicts = payload.get("optiverse_clipboard", [])
+        if not isinstance(item_dicts, list):
+            return []
+
+        return self._deserialize_item_dicts(item_dicts)
+
+    def _deserialize_item_dicts(self, item_dicts: list[dict]) -> list:
+        """Reconstruct scene items from a list of serialized dicts."""
+        import uuid as _uuid
+
+        from ...objects import RectangleItem
+        from ...objects.annotations import RulerItem, TextNoteItem
+        from ...objects.type_registry import deserialize_item
+
+        items = []
+        for d in item_dicts:
+            try:
+                item_type = d.get("type", d.get("_type", ""))
+                if item_type == "ruler":
+                    item = RulerItem.from_dict(d)
+                    item.item_uuid = str(_uuid.uuid4())
+                elif item_type == "text_note":
+                    item = TextNoteItem.from_dict(d)
+                    item.item_uuid = str(_uuid.uuid4())
+                elif item_type == "rectangle":
+                    item = RectangleItem.from_dict(d)
+                    item.item_uuid = str(_uuid.uuid4())
+                else:
+                    item = deserialize_item(d)
+                    if item is not None:
+                        item.item_uuid = str(_uuid.uuid4())
+
+                if item is not None:
+                    items.append(item)
+            except Exception:
+                pass
+        return items
+
+    def _paste_deserialized_items(
+        self,
+        items: list,
+        target_pos: QtCore.QPointF | None = None,
+    ) -> None:
+        """Add deserialized items to the scene with an optional target offset."""
+        from ...core import preferences
+        from ...core.undo_commands import PasteItemsCommand
+
+        if target_pos is not None:
+            centroid_x = 0.0
+            centroid_y = 0.0
+            for it in items:
+                p = it.pos()
+                centroid_x += p.x()
+                centroid_y += p.y()
+            if items:
+                centroid_x /= len(items)
+                centroid_y /= len(items)
+            dx = target_pos.x() - centroid_x
+            dy = target_pos.y() - centroid_y
+        else:
+            dx = preferences.clone_offset_x_mm
+            dy = preferences.clone_offset_y_mm
+
+        for it in items:
+            it.setPos(it.pos().x() + dx, it.pos().y() + dy)
+            self._connect_item_signals(it)
+
+        cmd = PasteItemsCommand(self.scene, items, self._layer_state)
+        self.undo_stack.push(cmd)
+
+        self.scene.clearSelection()
+        for it in items:
+            it.setSelected(True)
+
+        self._schedule_retrace()
+        self.log_service.info(
+            f"Pasted {len(items)} item(s) from another instance", LogCategory.COPY_PASTE
+        )
+
     @property
     def has_clipboard_items(self) -> bool:
-        """Check if clipboard has items for pasting."""
-        return len(self._clipboard) > 0
+        """Check if clipboard has items for pasting (local or system)."""
+        if self._clipboard:
+            return True
+        from PyQt6.QtGui import QGuiApplication
+
+        cb = QGuiApplication.clipboard()
+        if cb is not None:
+            mime = cb.mimeData()
+            if mime is not None and mime.hasFormat(self._MIME_TYPE):
+                return True
+        return False

--- a/src/optiverse/ui/controllers/component_operations.py
+++ b/src/optiverse/ui/controllers/component_operations.py
@@ -354,7 +354,7 @@ class ComponentOperationsHandler:
             return []
 
         try:
-            raw = bytes(mime.data(self._MIME_TYPE)).decode("utf-8")
+            raw = mime.data(self._MIME_TYPE).data().decode("utf-8")
             payload = json.loads(raw)
         except (json.JSONDecodeError, UnicodeDecodeError):
             return []
@@ -377,22 +377,20 @@ class ComponentOperationsHandler:
         for d in item_dicts:
             try:
                 item_type = d.get("type", d.get("_type", ""))
+                new_item: object | None = None
                 if item_type == "ruler":
-                    item = RulerItem.from_dict(d)
-                    item.item_uuid = str(_uuid.uuid4())
+                    new_item = RulerItem.from_dict(d)
                 elif item_type == "text_note":
-                    item = TextNoteItem.from_dict(d)
-                    item.item_uuid = str(_uuid.uuid4())
+                    new_item = TextNoteItem.from_dict(d)
                 elif item_type == "rectangle":
-                    item = RectangleItem.from_dict(d)
-                    item.item_uuid = str(_uuid.uuid4())
+                    new_item = RectangleItem.from_dict(d)
                 else:
-                    item = deserialize_item(d)
-                    if item is not None:
-                        item.item_uuid = str(_uuid.uuid4())
+                    new_item = deserialize_item(d)
 
-                if item is not None:
-                    items.append(item)
+                if new_item is not None:
+                    if hasattr(new_item, "item_uuid"):
+                        new_item.item_uuid = str(_uuid.uuid4())  # type: ignore[union-attr]
+                    items.append(new_item)
             except Exception:
                 pass
         return items

--- a/src/optiverse/ui/views/main_window.py
+++ b/src/optiverse/ui/views/main_window.py
@@ -130,6 +130,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # Connect drop signal instead of circular reference
         self.view.componentDropped.connect(self.on_drop_component)
         self.view.cursorScenePosChanged.connect(self._update_coord_label)
+        self.view.nudgeRequested.connect(self._nudge_selected)
         self.setCentralWidget(self.view)
 
         # Initialize OpenGL ray overlay for hardware-accelerated rendering
@@ -218,6 +219,9 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Initialize handlers that need actions (after action_builder creates them)
         self._init_event_handlers()
+
+        # Re-evaluate paste action whenever system clipboard changes
+        QtWidgets.QApplication.clipboard().dataChanged.connect(self._on_clipboard_changed)
 
         # Apply startup-only preferences (autotrace, ray width, autosave, max events)
         self.autotrace = self.settings_service.get_value("canvas/autotrace", True, bool)
@@ -634,6 +638,10 @@ class MainWindow(QtWidgets.QMainWindow):
     def _set_paste_enabled(self, enabled: bool) -> None:
         """Set paste action enabled state - used by handlers instead of lambda."""
         self.act_paste.setEnabled(enabled)
+
+    def _on_clipboard_changed(self) -> None:
+        """Re-evaluate paste action when the system clipboard changes."""
+        self.act_paste.setEnabled(self.component_ops.has_clipboard_items)
 
     def _on_path_measure_complete(self) -> None:
         """Called when path measure tool completes - used instead of lambda."""
@@ -1135,27 +1143,16 @@ class MainWindow(QtWidgets.QMainWindow):
             return result
         return super().eventFilter(obj, ev)
 
-    _ARROW_KEYS = {
-        QtCore.Qt.Key.Key_Left,
-        QtCore.Qt.Key.Key_Right,
-        QtCore.Qt.Key.Key_Up,
-        QtCore.Qt.Key.Key_Down,
-    }
-
     def keyPressEvent(self, ev):
         """Handle key press events (delegated to SceneEventHandler)."""
         if self.scene_event_handler.handle_key_press(ev):
             ev.accept()
             return
 
-        if ev.key() in self._ARROW_KEYS and self._nudge_selected(ev):
-            ev.accept()
-            return
-
         super().keyPressEvent(ev)
 
-    def _nudge_selected(self, ev: QtGui.QKeyEvent) -> bool:
-        """Move selected items by arrow key. Returns True if handled."""
+    def _nudge_selected(self, key: int, shift: bool) -> None:
+        """Move selected items by arrow key (connected to GraphicsView.nudgeRequested)."""
         from ...core import preferences
         from ...core.undo_commands import MoveItemCommand
         from ...objects import BaseObj
@@ -1168,19 +1165,18 @@ class MainWindow(QtWidgets.QMainWindow):
             if isinstance(it, (BaseObj, RulerItem, TextNoteItem, RectangleItem))
         ]
         if not selected:
-            return False
+            return
 
-        shift = ev.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier
         step = preferences.nudge_large_mm if shift else preferences.nudge_small_mm
 
         dx, dy = 0.0, 0.0
-        if ev.key() == QtCore.Qt.Key.Key_Left:
+        if key == QtCore.Qt.Key.Key_Left:
             dx = -step
-        elif ev.key() == QtCore.Qt.Key.Key_Right:
+        elif key == QtCore.Qt.Key.Key_Right:
             dx = step
-        elif ev.key() == QtCore.Qt.Key.Key_Up:
+        elif key == QtCore.Qt.Key.Key_Up:
             dy = step
-        elif ev.key() == QtCore.Qt.Key.Key_Down:
+        elif key == QtCore.Qt.Key.Key_Down:
             dy = -step
 
         for item in selected:
@@ -1190,7 +1186,6 @@ class MainWindow(QtWidgets.QMainWindow):
             self.undo_stack.push(cmd)
 
         self._schedule_retrace()
-        return True
 
     @staticmethod
     def _format_coord(mm_val: float, px_per_mm: float) -> str:

--- a/src/optiverse/ui/views/main_window.py
+++ b/src/optiverse/ui/views/main_window.py
@@ -109,6 +109,7 @@ class MainWindow(QtWidgets.QMainWindow):
     act_disconnect: QtGui.QAction
     act_import_as_layer: QtGui.QAction
     collab_status_label: QtWidgets.QLabel
+    coord_label: QtWidgets.QLabel
 
     def __init__(self):
         super().__init__()

--- a/src/optiverse/ui/views/main_window.py
+++ b/src/optiverse/ui/views/main_window.py
@@ -128,6 +128,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.view = GraphicsView(self.scene)
         # Connect drop signal instead of circular reference
         self.view.componentDropped.connect(self.on_drop_component)
+        self.view.cursorScenePosChanged.connect(self._update_coord_label)
         self.setCentralWidget(self.view)
 
         # Initialize OpenGL ray overlay for hardware-accelerated rendering
@@ -1133,13 +1134,68 @@ class MainWindow(QtWidgets.QMainWindow):
             return result
         return super().eventFilter(obj, ev)
 
+    _ARROW_KEYS = {
+        QtCore.Qt.Key.Key_Left,
+        QtCore.Qt.Key.Key_Right,
+        QtCore.Qt.Key.Key_Up,
+        QtCore.Qt.Key.Key_Down,
+    }
+
     def keyPressEvent(self, ev):
         """Handle key press events (delegated to SceneEventHandler)."""
         if self.scene_event_handler.handle_key_press(ev):
             ev.accept()
             return
-        # Pass to parent for normal handling (Delete/Backspace handled by act_delete action)
+
+        if ev.key() in self._ARROW_KEYS and self._nudge_selected(ev):
+            ev.accept()
+            return
+
         super().keyPressEvent(ev)
+
+    def _nudge_selected(self, ev: QtGui.QKeyEvent) -> bool:
+        """Move selected items by arrow key. Returns True if handled."""
+        from ...core import preferences
+        from ...core.undo_commands import MoveItemCommand
+        from ...objects import BaseObj
+        from ...objects.annotations import RulerItem
+        from ...objects.annotations.rectangle_item import RectangleItem
+        from ...objects.annotations.text_note_item import TextNoteItem
+
+        selected = [
+            it for it in self.scene.selectedItems()
+            if isinstance(it, (BaseObj, RulerItem, TextNoteItem, RectangleItem))
+        ]
+        if not selected:
+            return False
+
+        shift = ev.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier
+        step = preferences.nudge_large_mm if shift else preferences.nudge_small_mm
+
+        dx, dy = 0.0, 0.0
+        if ev.key() == QtCore.Qt.Key.Key_Left:
+            dx = -step
+        elif ev.key() == QtCore.Qt.Key.Key_Right:
+            dx = step
+        elif ev.key() == QtCore.Qt.Key.Key_Up:
+            dy = step
+        elif ev.key() == QtCore.Qt.Key.Key_Down:
+            dy = -step
+
+        for item in selected:
+            old_pos = item.pos()
+            new_pos = QtCore.QPointF(old_pos.x() + dx, old_pos.y() + dy)
+            cmd = MoveItemCommand(item, old_pos, new_pos)
+            self.undo_stack.push(cmd)
+
+        self._schedule_retrace()
+        return True
+
+    def _update_coord_label(self, pos: QtCore.QPointF) -> None:
+        """Update the status bar coordinate display."""
+        label = getattr(self, "coord_label", None)
+        if label is not None:
+            label.setText(f"X: {pos.x():.2f}  Y: {pos.y():.2f} mm")
 
     def show_log_window(self):
         """Show the application log window."""

--- a/src/optiverse/ui/views/main_window.py
+++ b/src/optiverse/ui/views/main_window.py
@@ -1192,11 +1192,36 @@ class MainWindow(QtWidgets.QMainWindow):
         self._schedule_retrace()
         return True
 
+    @staticmethod
+    def _format_coord(mm_val: float, px_per_mm: float) -> str:
+        """Format a coordinate value with zoom-appropriate units."""
+        mm_per_px = 1.0 / max(px_per_mm, 1e-12)
+        if mm_per_px < 0.001:
+            return f"{mm_val * 1e6:.1f}"
+        elif mm_per_px < 1.0:
+            return f"{mm_val * 1e3:.2f}"
+        else:
+            return f"{mm_val:.2f}"
+
+    @staticmethod
+    def _coord_unit(px_per_mm: float) -> str:
+        mm_per_px = 1.0 / max(px_per_mm, 1e-12)
+        if mm_per_px < 0.001:
+            return "nm"
+        elif mm_per_px < 1.0:
+            return "\u00b5m"
+        return "mm"
+
     def _update_coord_label(self, pos: QtCore.QPointF) -> None:
-        """Update the status bar coordinate display."""
+        """Update the status bar coordinate display with zoom-aware units."""
         label = getattr(self, "coord_label", None)
-        if label is not None:
-            label.setText(f"X: {pos.x():.2f}  Y: {pos.y():.2f} mm")
+        if label is None:
+            return
+        px_per_mm = abs(self.view.transform().m11())
+        unit = self._coord_unit(px_per_mm)
+        x_str = self._format_coord(pos.x(), px_per_mm)
+        y_str = self._format_coord(pos.y(), px_per_mm)
+        label.setText(f"X: {x_str}  Y: {y_str} {unit}")
 
     def show_log_window(self):
         """Show the application log window."""

--- a/src/optiverse/ui/views/settings_dialog.py
+++ b/src/optiverse/ui/views/settings_dialog.py
@@ -308,6 +308,26 @@ class SettingsDialog(QtWidgets.QDialog):
         form_cl.addRow("Clone offset Y:", self._spin_clone_y)
 
         layout.addWidget(grp_clip)
+
+        # Nudge (arrow key movement)
+        grp_nudge = QtWidgets.QGroupBox("Arrow Key Nudging")
+        form_nu = QtWidgets.QFormLayout(grp_nudge)
+
+        self._spin_nudge_small = QtWidgets.QDoubleSpinBox()
+        self._spin_nudge_small.setRange(0.01, 10.0)
+        self._spin_nudge_small.setSingleStep(0.1)
+        self._spin_nudge_small.setDecimals(2)
+        self._spin_nudge_small.setSuffix(" mm")
+        form_nu.addRow("Small step (Arrow):", self._spin_nudge_small)
+
+        self._spin_nudge_large = QtWidgets.QDoubleSpinBox()
+        self._spin_nudge_large.setRange(0.1, 100.0)
+        self._spin_nudge_large.setSingleStep(0.5)
+        self._spin_nudge_large.setDecimals(1)
+        self._spin_nudge_large.setSuffix(" mm")
+        form_nu.addRow("Large step (Shift+Arrow):", self._spin_nudge_large)
+
+        layout.addWidget(grp_nudge)
         layout.addStretch()
 
         scroll.setWidget(inner)
@@ -486,6 +506,12 @@ class SettingsDialog(QtWidgets.QDialog):
         )
         self._spin_clone_y.setValue(
             s.get_value("canvas/clone_offset_y_mm", 20.0, float)
+        )
+        self._spin_nudge_small.setValue(
+            s.get_value("canvas/nudge_small_mm", 0.1, float)
+        )
+        self._spin_nudge_large.setValue(
+            s.get_value("canvas/nudge_large_mm", 1.0, float)
         )
 
         # Export
@@ -760,6 +786,8 @@ class SettingsDialog(QtWidgets.QDialog):
         s.set_value("canvas/max_raytracing_events", self._spin_max_events.value())
         s.set_value("canvas/clone_offset_x_mm", self._spin_clone_x.value())
         s.set_value("canvas/clone_offset_y_mm", self._spin_clone_y.value())
+        s.set_value("canvas/nudge_small_mm", self._spin_nudge_small.value())
+        s.set_value("canvas/nudge_large_mm", self._spin_nudge_large.value())
 
         # Export
         s.set_value("export/default_png_scale", self._spin_png_scale.value())


### PR DESCRIPTION
## Summary

Implements six open feature requests and bug fixes in a single feature branch:

- **#78 - Live X/Y cursor coordinates**: Adds a permanent coordinate display in the status bar that updates as the cursor moves over the canvas, showing scene position in mm.
- **#79 - Dynamic scale bar units**: Scale bar now automatically switches between mm, µm, and nm at high zoom levels, with a dynamically sized bar that always represents a clean round number.
- **#80 - Thinner ruler boundaries at high zoom**: Ruler endpoint bars, labels, and text now maintain constant screen size regardless of zoom level (matching the existing cosmetic pen behavior for ruler lines).
- **#89 - Arrow key nudging**: Selected items can be moved with arrow keys (0.1 mm default step) or Shift+Arrow (1.0 mm). Both step sizes are configurable in Preferences > Canvas & Editing.
- **#90 - Configurable label positioning**: Ruler labels can now be placed Above, Below, Left, or Right relative to the segment. Setting is available in the ruler's Edit dialog and is serialized/undoable.
- **#34 - Cross-instance copy/paste**: Copy now serializes items to the system clipboard using a custom MIME type. Pasting in a different optiverse window deserializes and adds the items. Same-instance paste still uses the fast in-memory path.

## Files changed

| File | Changes |
|------|---------|
| `core/preferences.py` | Added `nudge_small_mm`, `nudge_large_mm` |
| `objects/annotations/ruler_item.py` | Zoom-invariant rendering, label positioning, serialization |
| `objects/views/graphics_view.py` | Cursor signal, mouse tracking, dynamic scale bar |
| `ui/builders/action_builder.py` | Coordinate label in status bar |
| `ui/controllers/component_operations.py` | System clipboard serialization/deserialization |
| `ui/views/main_window.py` | Coordinate display, arrow key nudging |
| `ui/views/settings_dialog.py` | Nudge step size settings UI |

## Test plan

- [ ] Move cursor over canvas — verify X/Y coordinates update in status bar
- [ ] Zoom in past mm scale — verify scale bar switches to µm, then nm
- [ ] Zoom into a ruler annotation — verify bars and labels stay constant size
- [ ] Select items and press arrow keys — verify they move by 0.1 mm
- [ ] Hold Shift+Arrow — verify 1.0 mm step
- [ ] Right-click ruler → Edit — verify Label Position combo box works
- [ ] Change label position — verify undo/redo works
- [ ] Save/reload file with non-default label position — verify persistence
- [ ] Copy items in one window, paste in another — verify cross-instance paste
- [ ] Verify same-instance copy/paste still works as before

Closes #78, #79, #80, #89, #90, #34

Made with [Cursor](https://cursor.com)