### PR TITLE
docs: fix stale README references and version comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ Optiverse is a powerful, interactive tool for designing and simulating optical s
 - **Component Editor**: Create custom optical components with multiple interfaces (lenses, mirrors, beamsplitters)
 - **Hardware-Accelerated Rendering**: OpenGL-powered ray display (100x+ faster than software rendering)
 - **Numba JIT Optimization**: 4-8x raytracing speedup on all Python versions (3.9-3.12+)
+- **Linked Assemblies**: Reference external assembly files with file-watching and "Edit in Context" workflow
+- **Locking System**: Lock individual items, groups, rulers, and text notes against movement, rotation, and deletion
+- **Autolabel**: Automatically display key optical properties (e.g. `f = 100 mm`, `QWP @ 45°`) as labels that follow their owner
+- **Measurement Tools**: Rulers and angle-measure tools with zoom-invariant rendering and per-segment editing
+- **Live Cursor Coordinates & Dynamic Scale Bar**: Status bar coordinates and scale bar adapt units (mm/µm/nm) to zoom level
 - **Collaboration Mode**: Real-time multi-user editing via WebSocket server
 - **Zemax Import**: Import optical designs from Zemax (.zmx) files
 - **Polarization Support**: Jones vector formalism for polarization-dependent optics
 - **Platform-Native UI**: macOS trackpad gestures, native menu bars, dark mode support
+
+See [CHANGELOG.md](CHANGELOG.md) for the full list of changes between releases.
 
 ## Installation
 
@@ -305,18 +312,6 @@ black src/ tests/
 python tools/create_icon.py
 ```
 
-### Testing Platform Features
-```bash
-# Test macOS optimizations
-python tools/test_mac_optimizations.py
-
-# Test collaboration
-python tools/test_collaboration.py
-
-# Manual save/load testing
-python tools/test_save_load_manual.py
-```
-
 ## Project Structure
 
 ```
@@ -339,15 +334,17 @@ optiverse/
 
 ## Feature Requests & Bugs
 
-### Known Bugs
-- colaborative work is broken
-- waveplates do not always rotate the polarization correctly
-- QWP seems to adjust polarisation correctly but PBS does not reflect correctly in the pbs + qwp + backreflector mirror config.
+For the authoritative list of open bugs and feature requests, see [GitHub Issues](https://github.com/QPG-MIT/optiverse/issues).
 
-### Feature Requests
-- zemax black box model
-- isolator
-- distance measure tool across edges
+### Known Bugs
+- Collaborative editing is currently broken
+- Waveplates do not always rotate polarization correctly
+- PBS does not reflect correctly in the PBS + QWP + back-reflector mirror configuration (QWP itself adjusts polarization correctly)
+
+### Notable Feature Requests
+- Zemax black-box model import
+- Optical isolator component
+- Distance-measure tool across edges
 
 
 ## Contributing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,14 +7,14 @@ name = "optiverse"
 version = "0.3.4"
 description = "Optiverse: 2D ray-optics sandbox and component editor (PyQt6, modular)"
 readme = "README.md"
-requires-python = ">=3.9"  # 3.9-3.11 recommended for Numba JIT speedup
+requires-python = ">=3.9"  # 3.9-3.12+ fully supported with Numba JIT speedup (Numba 0.60+)
 license = { text = "MIT" }
 authors = [{ name = "QPG-MIT" }]
 dependencies = [
   "PyQt6>=6.5",
   "PyQt6-WebEngine>=6.5",
   "numpy>=1.24",
-  "numba>=0.58",  # JIT compilation for 4-8x raytracing speedup (Python 3.9-3.11)
+  "numba>=0.58",  # JIT compilation for 4-8x raytracing speedup (Python 3.9-3.12+ via Numba 0.60+)
   "PyOpenGL>=3.1.10",  # Hardware-accelerated ray rendering
   "websockets>=12.0",
   "pyobjc-framework-Cocoa>=10.0; sys_platform == 'darwin'",  # macOS menu bar app name


### PR DESCRIPTION
## Summary

Audited `README.md` against the current repo state and fixed the inaccuracies that turned up:

- **Removed "Testing Platform Features" section** — it referenced three scripts (`tools/test_mac_optimizations.py`, `tools/test_collaboration.py`, `tools/test_save_load_manual.py`) that don't exist in `tools/`.
- **Fixed `colaborative` typo** and rewrote the known-bugs / feature-requests bullets in proper sentence case. Added a pointer to GitHub Issues as the authoritative list so this section doesn't drift again.
- **Surfaced recent features in the headline list** that were already in `CHANGELOG.md` but missing from the top of the README: Linked Assemblies, Locking System, Autolabel, Measurement Tools (rulers / angle-measure), and Live Cursor Coordinates / Dynamic Scale Bar. Also linked `CHANGELOG.md` for the full list.
- **Updated `pyproject.toml` comments** that still claimed Python 3.9–3.11 for Numba speedup, contradicting the README's own correction note that 3.12+ is fully supported via Numba 0.60+.

No code or behavior changes.

## Test plan

- [ ] Render the README on GitHub and confirm the new feature bullets, CHANGELOG link, and GitHub Issues link all display correctly
- [ ] Confirm `tools/` directory listing matches what the README now describes (no references to deleted scripts)
- [ ] Confirm `pyproject.toml` still installs (`pip install -e .`) — comment-only change, but worth a smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)