### PR TITLE
docs: correct raytracing package docstring to RayState

### DIFF
--- a/src/optiverse/raytracing/__init__.py
+++ b/src/optiverse/raytracing/__init__.py
@@ -5,7 +5,7 @@ This module provides a clean, polymorphic raytracing implementation with
 no UI dependencies. Can be used independently or in background threads.
 
 Architecture:
-    - Ray: Data structure for ray state
+    - RayState: Data structure for ray state
     - RayPath: Data structure for traced path
     - Polarization: Jones vector formalism
     - IOpticalElement: Interface for all optical elements


### PR DESCRIPTION
## What
Fixes a one-line inaccuracy in the `optiverse.raytracing` package docstring.

The Architecture list named the ray-state class as `Ray`, but the canonical class is `RayState` (`Ray` is only a backward-compatibility alias defined at the bottom of `ray.py`). This updates the docstring to match the real class name.

## Why
Documentation accuracy only — the docstring described the type as "ray state" while naming it `Ray`. No functional change: imports, `__all__`, and the `Ray` alias are all untouched.

## Scope
- `src/optiverse/raytracing/__init__.py` — 1 line changed.