### PR TITLE
fix: prevent absolute image paths from being written to save files

### DIFF
--- a/src/optiverse/core/models.py
+++ b/src/optiverse/core/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -143,10 +144,10 @@ def serialize_component(rec: ComponentRecord, settings_service=None) -> dict[str
     Image paths are stored using the following priority:
     1. Library-relative format (@library/...) if within a configured library
     2. Package-relative format if within the package (built-in components)
-    3. Absolute path as fallback
+    3. Empty string if the image is outside all known locations (never absolute)
 
-    This makes assemblies portable across different computers while maintaining
-    backward compatibility with absolute paths.
+    Absolute paths are never written so that save files remain portable across
+    different computers and home-directory layouts.
 
     Args:
         rec: ComponentRecord to serialize
@@ -167,11 +168,11 @@ def serialize_component(rec: ComponentRecord, settings_service=None) -> dict[str
             image_path_serialized = library_relative
         else:
             # Fall back to package-relative (for built-in components)
-            if rec.image_path:
-                rel_path = to_relative_path(rec.image_path)
-                image_path_serialized = rel_path if isinstance(rel_path, str) else str(rel_path)
-            else:
-                image_path_serialized = ""
+            rel_path = to_relative_path(rec.image_path)
+            if rel_path and not Path(rel_path).is_absolute():
+                image_path_serialized = rel_path
+            # else: image is outside both library and package — don't write an
+            # absolute path; image_path_serialized stays as ""
 
     base = {
         "name": rec.name,


### PR DESCRIPTION
## Summary

- `serialize_component` was writing raw absolute paths to `image_path` in save files whenever a component's image lived outside both the built-in package and all configured libraries
- `to_relative_path()` explicitly falls back to returning the absolute path for such images, and the old code used its return value unconditionally
- Fix: check `Path(rel_path).is_absolute()` after the call and leave `image_path_serialized` as `""` if still absolute — no absolute paths ever reach the save file

Also removes a dead-code inner `if rec.image_path / else: ""` branch (unreachable since the outer guard already ensures `rec.image_path` is truthy).

## Serialization priority (unchanged except last step)

| Case | Stored as |
|---|---|
| Image in a configured library | `@library/{lib}/{component}/...` |
| Image in the package (built-ins) | package-relative path |
| Image outside both | `""` (was: absolute path) |

## Test plan

- [ ] Run `pytest tests/core/test_component_record.py` — all 14 tests pass
- [ ] Open a scene with a custom component whose image is in the user library, save and reload — image still loads via `@library/...` path
- [ ] Open a scene with a component whose image is outside all libraries, save — confirm `image_path` is `""` in the JSON rather than an absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)