### PR TITLE
Fix layer rename reverting to default; auto-index duplicate names (#103)

### DIFF
--- a/src/optiverse/core/models.py
+++ b/src/optiverse/core/models.py
@@ -263,6 +263,9 @@ class SourceParams:
     x_mm: float = -400.0
     y_mm: float = 0.0
     angle_deg: float = 0.0
+    # Custom layer-panel name (None = fall back to the "Source" type label).
+    # Without this field a source rename had nowhere to be stored and reverted.
+    name: str | None = None
     size_mm: float = 10.0
     n_rays: int = 9
     ray_length_mm: float = 1000.0

--- a/src/optiverse/objects/annotations/text_note_item.py
+++ b/src/optiverse/objects/annotations/text_note_item.py
@@ -267,6 +267,7 @@ class TextNoteItem(QtWidgets.QGraphicsTextItem):
 
         new_item = TextNoteItem(self.toPlainText())
 
+        new_item.display_name = self.display_name  # keep custom layer name for indexing
         new_item.setDefaultTextColor(self.defaultTextColor())
         new_item.setFont(self.font())
         new_item.setZValue(self.zValue())

--- a/src/optiverse/objects/annotations/text_note_item.py
+++ b/src/optiverse/objects/annotations/text_note_item.py
@@ -290,6 +290,8 @@ class TextNoteItem(QtWidgets.QGraphicsTextItem):
         }
         if self._locked:
             d["locked"] = True
+        if self.display_name:
+            d["display_name"] = self.display_name
         if self.owner_uuid is not None:
             d["owner_uuid"] = self.owner_uuid
             d["owner_offset_x"] = float(self._owner_offset.x())
@@ -319,6 +321,8 @@ class TextNoteItem(QtWidgets.QGraphicsTextItem):
             item.setZValue(float(d["z_value"]))
         if d.get("locked"):
             item.set_locked(True)
+        if d.get("display_name"):
+            item.display_name = str(d["display_name"])
 
         # Restore autolabel link
         owner_uuid = d.get("owner_uuid")

--- a/src/optiverse/objects/naming.py
+++ b/src/optiverse/objects/naming.py
@@ -1,0 +1,62 @@
+"""Shared helpers for the display names shown in the layer panel.
+
+The label for a scene item is resolved the same way in three places (the layer
+model, the rename command, and duplicate auto-indexing), so the logic lives here
+once: ``display_name`` → ``params.name`` → prettified ``type_name``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PyQt6 import QtWidgets
+
+
+def item_label(item: object) -> str:
+    """Return the label shown for *item* in the layer panel.
+
+    Mirrors ``LayerItemModel._get_item_name``: a custom ``display_name`` wins,
+    then ``params.name``, then the item's ``type_name`` (prettified).
+    """
+    display_name = getattr(item, "display_name", None)
+    if display_name:
+        return str(display_name)
+    params = getattr(item, "params", None)
+    name = getattr(params, "name", None) if params is not None else None
+    if name:
+        return str(name)
+    type_name = getattr(item, "type_name", None)
+    return type_name.replace("_", " ").title() if type_name else "Item"
+
+
+def set_item_label(item: object, name: str) -> None:
+    """Write *name* to the item's rename target (``display_name`` or ``params.name``)."""
+    if hasattr(item, "display_name"):
+        item.display_name = name
+        return
+    params = getattr(item, "params", None)
+    if params is not None and hasattr(params, "name"):
+        params.name = name
+
+
+def assign_unique_name(scene: QtWidgets.QGraphicsScene, item: object) -> None:
+    """Give *item* a duplicate-free label: ``Lens`` → ``Lens 2`` → ``Lens 3``.
+
+    Compares the item's default label against every other named item already in
+    *scene*. The first element of a kind keeps its bare name; only collisions get
+    a numeric suffix. Call this on freshly created items *before* adding them to
+    the scene (the new item is excluded from the comparison either way).
+    """
+    base = item_label(item)
+    existing = {
+        item_label(other)
+        for other in scene.items()
+        if other is not item and hasattr(other, "item_uuid")
+    }
+    if base not in existing:
+        return
+    n = 2
+    while f"{base} {n}" in existing:
+        n += 1
+    set_item_label(item, f"{base} {n}")

--- a/src/optiverse/objects/naming.py
+++ b/src/optiverse/objects/naming.py
@@ -40,23 +40,52 @@ def set_item_label(item: object, name: str) -> None:
         params.name = name
 
 
-def assign_unique_name(scene: QtWidgets.QGraphicsScene, item: object) -> None:
+def _is_nameable(item: object) -> bool:
+    """True for user-facing layer rows.
+
+    Excludes autolabels (a ``TextNoteItem`` with an ``owner_uuid``), which show
+    their owner's optical property and are not independently renameable — they
+    must not take part in duplicate indexing or be counted as taken names.
+    """
+    return hasattr(item, "item_uuid") and getattr(item, "owner_uuid", None) is None
+
+
+def assign_unique_name(
+    scene: QtWidgets.QGraphicsScene, item: object, *, reserved: set[str] | None = None
+) -> str:
     """Give *item* a duplicate-free label: ``Lens`` → ``Lens 2`` → ``Lens 3``.
 
     Compares the item's default label against every other named item already in
-    *scene*. The first element of a kind keeps its bare name; only collisions get
-    a numeric suffix. Call this on freshly created items *before* adding them to
-    the scene (the new item is excluded from the comparison either way).
+    *scene* (plus any names in *reserved*, used to keep a multi-item paste batch
+    internally unique). The first element of a kind keeps its bare name; only
+    collisions get a numeric suffix. Call on freshly created items *before*
+    adding them to the scene. Returns the final label.
     """
     base = item_label(item)
+    if not _is_nameable(item):
+        return base
     existing = {
         item_label(other)
         for other in scene.items()
-        if other is not item and hasattr(other, "item_uuid")
+        if other is not item and _is_nameable(other)
     }
+    if reserved:
+        existing |= reserved
     if base not in existing:
-        return
+        return base
     n = 2
     while f"{base} {n}" in existing:
         n += 1
-    set_item_label(item, f"{base} {n}")
+    new_name = f"{base} {n}"
+    set_item_label(item, new_name)
+    return new_name
+
+
+def assign_unique_names(scene: QtWidgets.QGraphicsScene, items: list[object]) -> None:
+    """Auto-index a batch (e.g. a paste/duplicate) so it stays unique against the
+    scene *and* against the rest of the batch. Autolabels are skipped."""
+    taken: set[str] = set()
+    for item in items:
+        if not _is_nameable(item):
+            continue
+        taken.add(assign_unique_name(scene, item, reserved=taken))

--- a/src/optiverse/ui/controllers/component_operations.py
+++ b/src/optiverse/ui/controllers/component_operations.py
@@ -105,6 +105,11 @@ class ComponentOperationsHandler:
         # Connect signals
         self._connect_item_signals(item)
 
+        # Auto-index duplicate names (e.g. second "Lens" becomes "Lens 2")
+        from ...objects.naming import assign_unique_name
+
+        assign_unique_name(self.scene, item)
+
         # Add to scene with undo support
         cmd = AddItemCommand(self.scene, item, self._layer_state)
         self.undo_stack.push(cmd)

--- a/src/optiverse/ui/controllers/component_operations.py
+++ b/src/optiverse/ui/controllers/component_operations.py
@@ -334,6 +334,12 @@ class ComponentOperationsHandler:
                 f"Successfully pasted {len(pasted_items)} item(s)", LogCategory.COPY_PASTE
             )
 
+            # Auto-index duplicate names across the scene and within this batch
+            # (a pasted/duplicated "Lens" becomes "Lens 2", two at once "Lens 2"/"Lens 3")
+            from ...objects.naming import assign_unique_names
+
+            assign_unique_names(self.scene, pasted_items)
+
             cmd = PasteItemsCommand(self.scene, pasted_items, self._layer_state)
             self.undo_stack.push(cmd)
 
@@ -428,6 +434,11 @@ class ComponentOperationsHandler:
         for it in items:
             it.setPos(it.pos().x() + dx, it.pos().y() + dy)
             self._connect_item_signals(it)
+
+        # Auto-index duplicate names against the scene and within this batch
+        from ...objects.naming import assign_unique_names
+
+        assign_unique_names(self.scene, items)
 
         cmd = PasteItemsCommand(self.scene, items, self._layer_state)
         self.undo_stack.push(cmd)

--- a/src/optiverse/ui/models/layer_item_model.py
+++ b/src/optiverse/ui/models/layer_item_model.py
@@ -440,14 +440,12 @@ class LayerItemModel(QtCore.QAbstractItemModel):
             self._layer_state.remove_item(uid, emit=False)
 
     def _get_item_name(self, uuid: str) -> str:
+        from ...objects.naming import item_label
+
         item = self._get_live_item(uuid)
         if not item:
             return "Item"
-        if hasattr(item, "display_name") and item.display_name:
-            return str(item.display_name)
-        if hasattr(item, "params") and hasattr(item.params, "name") and item.params.name:
-            return str(item.params.name)
-        return item.type_name.replace("_", " ").title() if hasattr(item, "type_name") else "Item"
+        return item_label(item)
 
     def _uuids_from_indexes(self, indexes: list[QtCore.QModelIndex]) -> list[str]:
         uuids: list[str] = []

--- a/src/optiverse/ui/views/placement_handler.py
+++ b/src/optiverse/ui/views/placement_handler.py
@@ -405,6 +405,11 @@ class PlacementHandler:
         if component_type not in ("text", "rectangle"):
             self._connect_item_signals(placed_item)
 
+        # Auto-index duplicate names (e.g. second "Lens" becomes "Lens 2")
+        from ...objects.naming import assign_unique_name
+
+        assign_unique_name(self.scene, placed_item)
+
         # Add to scene with undo support
         cmd = AddItemCommand(self.scene, placed_item, self._layer_state)
         self.undo_stack.push(cmd)

--- a/src/optiverse/ui/widgets/layer_panel.py
+++ b/src/optiverse/ui/widgets/layer_panel.py
@@ -171,6 +171,12 @@ class LayerPanel(QtWidgets.QWidget):
     def _do_refresh(self) -> None:
         if not self._scene:
             return
+        # Never reset the model while the user is renaming a layer: a
+        # beginResetModel/endResetModel tears down the open inline editor and the
+        # typed name is lost. Defer until the edit finishes.
+        if self._tree.state() == QtWidgets.QAbstractItemView.State.EditingState:
+            self._refresh_timer.start(100)
+            return
         self._model.set_context(
             scene=self._scene,
             layer_state=self._layer_state,
@@ -279,6 +285,11 @@ class LayerPanel(QtWidgets.QWidget):
 
     def _do_sync_from_scene_selection(self) -> None:
         if not self._scene:
+            return
+        # Selecting a layer for rename triggers this sync; clearing/reselecting
+        # the tree's selection mid-edit closes the inline editor before the name
+        # is committed. Skip while editing — a later selection change re-syncs.
+        if self._tree.state() == QtWidgets.QAbstractItemView.State.EditingState:
             return
         uuids = {
             item.item_uuid for item in self._scene.selectedItems() if hasattr(item, "item_uuid")

--- a/tests/core/test_naming.py
+++ b/tests/core/test_naming.py
@@ -1,0 +1,144 @@
+"""Unit tests for layer-name resolution and duplicate auto-indexing (issue #103).
+
+These exercise ``optiverse.objects.naming`` with lightweight duck-typed fakes so
+they run without a QApplication (and therefore in the headless CI suite, which
+skips ``tests/ui``). The Qt model/view and serialization integration is covered
+separately in ``tests/ui/test_layer_rename_and_autoindex.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from optiverse.objects.naming import (
+    assign_unique_name,
+    assign_unique_names,
+    item_label,
+    set_item_label,
+)
+
+_uid = 0
+
+
+def _next_uuid() -> str:
+    global _uid
+    _uid += 1
+    return f"uuid-{_uid}"
+
+
+class FakeScene:
+    """Minimal stand-in for QGraphicsScene exposing ``items()``."""
+
+    def __init__(self, items=()):
+        self._items = list(items)
+
+    def items(self):
+        return list(self._items)
+
+    def add(self, item):
+        self._items.append(item)
+        return item
+
+
+def component(name=None):
+    """Component-like item: label comes from ``params.name`` (falls back to type)."""
+    return SimpleNamespace(
+        item_uuid=_next_uuid(),
+        params=SimpleNamespace(name=name),
+        type_name="component",
+        owner_uuid=None,
+    )
+
+
+def text(display_name=None, owner_uuid=None):
+    """Text-like item: label comes from ``display_name`` (falls back to type)."""
+    return SimpleNamespace(
+        item_uuid=_next_uuid(),
+        display_name=display_name,
+        type_name="text",
+        owner_uuid=owner_uuid,
+    )
+
+
+# --- label resolution -------------------------------------------------------
+def test_item_label_resolution_order():
+    assert item_label(text(display_name="Custom")) == "Custom"
+    assert item_label(component(name="Achromat")) == "Achromat"
+    assert item_label(component(name=None)) == "Component"  # type_name fallback
+    assert item_label(SimpleNamespace(type_name="beam_source")) == "Beam Source"
+
+
+def test_set_item_label_targets_the_right_field():
+    t = text()
+    set_item_label(t, "Note A")
+    assert t.display_name == "Note A"
+
+    c = component(name="Lens")
+    set_item_label(c, "Lens 2")
+    assert c.params.name == "Lens 2"
+
+
+# --- single-add auto-indexing ----------------------------------------------
+def test_first_of_a_kind_keeps_bare_name():
+    scene = FakeScene()
+    c = component("Lens")
+    assert assign_unique_name(scene, c) == "Lens"
+    assert c.params.name == "Lens"  # unchanged
+
+
+def test_sequential_adds_increment():
+    scene = FakeScene()
+    labels = []
+    for _ in range(3):
+        c = component("Lens")
+        assign_unique_name(scene, c)
+        scene.add(c)
+        labels.append(item_label(c))
+    assert labels == ["Lens", "Lens 2", "Lens 3"]
+
+
+def test_gap_is_refilled():
+    scene = FakeScene()
+    kept = []
+    for _ in range(3):  # Lens, Lens 2, Lens 3
+        c = component("Lens")
+        assign_unique_name(scene, c)
+        scene.add(c)
+        kept.append(c)
+    scene._items.remove(kept[1])  # drop "Lens 2"
+
+    c = component("Lens")
+    assign_unique_name(scene, c)
+    assert item_label(c) == "Lens 2"
+
+
+# --- batch (paste / duplicate) auto-indexing --------------------------------
+def test_batch_is_unique_against_scene_and_itself():
+    scene = FakeScene([component("Lens")])  # scene already has "Lens"
+    batch = [component("Lens"), component("Lens")]
+    assign_unique_names(scene, batch)
+    assert [item_label(b) for b in batch] == ["Lens 2", "Lens 3"]
+
+
+def test_batch_of_distinct_kinds():
+    scene = FakeScene([component("Lens"), component("Mirror")])
+    batch = [component("Lens"), component("Mirror")]
+    assign_unique_names(scene, batch)
+    assert [item_label(b) for b in batch] == ["Lens 2", "Mirror 2"]
+
+
+# --- autolabels are excluded ------------------------------------------------
+def test_autolabel_not_counted_as_taken():
+    scene = FakeScene([text(owner_uuid="owner-1")])  # autolabel resolves to "Text"
+    note = text()
+    assign_unique_name(scene, note)
+    assert item_label(note) == "Text"  # not bumped to "Text 2"
+
+
+def test_autolabel_in_batch_is_left_untouched():
+    scene = FakeScene()
+    autolabel = text(owner_uuid="owner-2")
+    note = text()
+    assign_unique_names(scene, [autolabel, note])
+    assert autolabel.display_name is None  # never renamed
+    assert item_label(note) == "Text"

--- a/tests/ui/test_layer_rename_and_autoindex.py
+++ b/tests/ui/test_layer_rename_and_autoindex.py
@@ -38,38 +38,9 @@ def _uuid_index(model, item):
 
 
 # --------------------------------------------------------------------------- #
-# Defect 2: source rename must persist (SourceParams.name now exists)
-# --------------------------------------------------------------------------- #
-def test_source_rename_persists_at_model_level(qtbot):
-    from PyQt6 import QtCore
-
-    from optiverse.core.layer_tree_state import LayerTreeState
-    from optiverse.core.models import SourceParams
-    from optiverse.core.undo_stack import UndoStack
-    from optiverse.objects.sources.source_item import SourceItem
-    from optiverse.ui.models.layer_item_model import LayerItemModel
-
-    scene = QtWidgets.QGraphicsScene()
-    src = SourceItem(SourceParams())
-    scene.addItem(src)
-    ls = LayerTreeState()
-    ls.add_item(src.item_uuid, None, 0, emit=False)
-
-    model = LayerItemModel()
-    model.set_context(scene=scene, layer_state=ls, undo_stack=UndoStack())
-    idx = _uuid_index(model, src)
-
-    # Default label falls back to the type name.
-    assert model.data(idx, int(QtCore.Qt.ItemDataRole.DisplayRole)) == "Source"
-
-    ok = model.setData(idx, "Pump Laser", int(QtCore.Qt.ItemDataRole.EditRole))
-    assert ok is True
-    assert src.params.name == "Pump Laser"
-    assert model.data(idx, int(QtCore.Qt.ItemDataRole.DisplayRole)) == "Pump Laser"
-
-
-# --------------------------------------------------------------------------- #
-# Defect 1: rename must survive a refresh/sync that fires while the editor is open
+# Defect 1 + 2: rename must survive a refresh/sync firing while the editor is
+# open, and must persist for a source (whose name had nowhere to be stored).
+# Renaming here drives the full model/view path: setData -> RenameNodeCommand.
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("kind", ["source", "text"])
 def test_rename_survives_refresh_and_sync_during_edit(qtbot, kind):
@@ -115,40 +86,26 @@ def test_rename_survives_refresh_and_sync_during_edit(qtbot, kind):
 
 
 # --------------------------------------------------------------------------- #
-# Feature: auto-indexing duplicate names
+# Auto-indexing through real scene items (logic is unit-tested in
+# tests/core/test_naming.py; this checks it against actual QGraphicsItems).
 # --------------------------------------------------------------------------- #
-def test_assign_unique_name_indexes_duplicates(qtbot):
+def test_assign_unique_name_indexes_real_items(qtbot):
     from optiverse.core.models import SourceParams
-    from optiverse.objects.naming import assign_unique_name, item_label
+    from optiverse.objects.naming import assign_unique_names, item_label
     from optiverse.objects.sources.source_item import SourceItem
 
     scene = QtWidgets.QGraphicsScene()
-    labels = []
-    for _ in range(3):
-        s = SourceItem(SourceParams())
-        assign_unique_name(scene, s)  # compare before adding
-        scene.addItem(s)
-        labels.append(item_label(s))
+    original = SourceItem(SourceParams())
+    scene.addItem(original)  # label "Source" already present
 
-    assert labels == ["Source", "Source 2", "Source 3"]
+    batch = [SourceItem(SourceParams()), SourceItem(SourceParams())]
+    assign_unique_names(scene, batch)  # simulates pasting/duplicating two clones
 
-
-def test_assign_unique_name_fills_gap(qtbot):
-    from optiverse.objects.annotations.text_note_item import TextNoteItem
-    from optiverse.objects.naming import assign_unique_name, item_label
-
-    scene = QtWidgets.QGraphicsScene()
-    keep = []
-    for _ in range(3):  # Text, Text 2, Text 3
-        t = TextNoteItem("Text")
-        assign_unique_name(scene, t)
-        scene.addItem(t)
-        keep.append(t)
-    scene.removeItem(keep[1])  # remove "Text 2"
-
-    t = TextNoteItem("Text")
-    assign_unique_name(scene, t)
-    assert item_label(t) == "Text 2"  # gap refilled
+    assert [item_label(original), item_label(batch[0]), item_label(batch[1])] == [
+        "Source",
+        "Source 2",
+        "Source 3",
+    ]
 
 
 # --------------------------------------------------------------------------- #
@@ -173,3 +130,20 @@ def test_text_display_name_survives_serialization(qtbot):
     note.display_name = "Collimator Label"
     restored = TextNoteItem.from_dict(note.to_dict())
     assert restored.display_name == "Collimator Label"
+
+
+def test_clone_preserves_display_name_for_indexing(qtbot):
+    """Duplicating a renamed text note keeps the custom name so it indexes on it."""
+    from optiverse.objects.annotations.text_note_item import TextNoteItem
+    from optiverse.objects.naming import assign_unique_names, item_label
+
+    scene = QtWidgets.QGraphicsScene()
+    original = TextNoteItem("body")
+    original.display_name = "My Note"
+    scene.addItem(original)
+
+    clone = original.clone((10.0, 10.0))
+    assert clone.display_name == "My Note"
+
+    assign_unique_names(scene, [clone])
+    assert item_label(clone) == "My Note 2"

--- a/tests/ui/test_layer_rename_and_autoindex.py
+++ b/tests/ui/test_layer_rename_and_autoindex.py
@@ -1,0 +1,175 @@
+"""Regression tests for issue #103: layer rename persistence + duplicate auto-indexing.
+
+Three rename defects are covered:
+  1. A debounced panel refresh/selection-sync firing mid-edit tore down the inline
+     editor before the typed name was committed (affected all item types).
+  2. SourceParams had no ``name`` field, so a source rename wrote nowhere and reverted.
+  3. TextNoteItem.display_name was not serialized, losing text renames on reload.
+
+Plus the auto-indexing feature (``Lens`` -> ``Lens 2`` -> ``Lens 3``).
+"""
+
+import os
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt6 import QtWidgets  # noqa: F401
+
+    HAVE_PYQT6 = True
+except ImportError:
+    HAVE_PYQT6 = False
+
+pytestmark = pytest.mark.skipif(not HAVE_PYQT6, reason="PyQt6 not available")
+
+
+def _uuid_index(model, item):
+    """Find the model index whose node maps to *item*."""
+    from PyQt6 import QtCore
+
+    for r in range(model.rowCount(QtCore.QModelIndex())):
+        idx = model.index(r, 0, QtCore.QModelIndex())
+        node = model._node_from_index(idx)
+        if node and node.uuid == item.item_uuid:
+            return idx
+    raise AssertionError("item not found in model")
+
+
+# --------------------------------------------------------------------------- #
+# Defect 2: source rename must persist (SourceParams.name now exists)
+# --------------------------------------------------------------------------- #
+def test_source_rename_persists_at_model_level(qtbot):
+    from PyQt6 import QtCore
+
+    from optiverse.core.layer_tree_state import LayerTreeState
+    from optiverse.core.models import SourceParams
+    from optiverse.core.undo_stack import UndoStack
+    from optiverse.objects.sources.source_item import SourceItem
+    from optiverse.ui.models.layer_item_model import LayerItemModel
+
+    scene = QtWidgets.QGraphicsScene()
+    src = SourceItem(SourceParams())
+    scene.addItem(src)
+    ls = LayerTreeState()
+    ls.add_item(src.item_uuid, None, 0, emit=False)
+
+    model = LayerItemModel()
+    model.set_context(scene=scene, layer_state=ls, undo_stack=UndoStack())
+    idx = _uuid_index(model, src)
+
+    # Default label falls back to the type name.
+    assert model.data(idx, int(QtCore.Qt.ItemDataRole.DisplayRole)) == "Source"
+
+    ok = model.setData(idx, "Pump Laser", int(QtCore.Qt.ItemDataRole.EditRole))
+    assert ok is True
+    assert src.params.name == "Pump Laser"
+    assert model.data(idx, int(QtCore.Qt.ItemDataRole.DisplayRole)) == "Pump Laser"
+
+
+# --------------------------------------------------------------------------- #
+# Defect 1: rename must survive a refresh/sync that fires while the editor is open
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("kind", ["source", "text"])
+def test_rename_survives_refresh_and_sync_during_edit(qtbot, kind):
+    from PyQt6 import QtCore
+
+    from optiverse.core.layer_tree_state import LayerTreeState
+    from optiverse.core.models import SourceParams
+    from optiverse.objects.annotations.text_note_item import TextNoteItem
+    from optiverse.objects.naming import item_label
+    from optiverse.objects.sources.source_item import SourceItem
+    from optiverse.ui.widgets.layer_panel import LayerPanel
+
+    scene = QtWidgets.QGraphicsScene()
+    item = SourceItem(SourceParams()) if kind == "source" else TextNoteItem("Text")
+    scene.addItem(item)
+    ls = LayerTreeState()
+    ls.add_item(item.item_uuid, None, 0, emit=False)
+
+    panel = LayerPanel()
+    qtbot.addWidget(panel)
+    panel.set_layer_state(ls)
+    panel.set_scene(scene)
+
+    tree, model = panel._tree, panel._model
+    idx = _uuid_index(model, item)
+    tree.setCurrentIndex(idx)
+    tree.edit(idx)
+    editor = tree.findChild(QtWidgets.QLineEdit)
+    assert editor is not None
+    editor.setText("Renamed")
+
+    # These debounced callbacks previously tore down the editor mid-edit. With the
+    # EditingState guard they must be no-ops while the editor is open.
+    panel._do_sync_from_scene_selection()
+    panel._do_refresh()
+    assert tree.findChild(QtWidgets.QLineEdit) is not None  # editor survived
+
+    tree.commitData(editor)
+    tree.closeEditor(editor, QtWidgets.QAbstractItemDelegate.EndEditHint.SubmitModelCache)
+
+    assert item_label(item) == "Renamed"
+    assert model.data(idx, int(QtCore.Qt.ItemDataRole.DisplayRole)) == "Renamed"
+
+
+# --------------------------------------------------------------------------- #
+# Feature: auto-indexing duplicate names
+# --------------------------------------------------------------------------- #
+def test_assign_unique_name_indexes_duplicates(qtbot):
+    from optiverse.core.models import SourceParams
+    from optiverse.objects.naming import assign_unique_name, item_label
+    from optiverse.objects.sources.source_item import SourceItem
+
+    scene = QtWidgets.QGraphicsScene()
+    labels = []
+    for _ in range(3):
+        s = SourceItem(SourceParams())
+        assign_unique_name(scene, s)  # compare before adding
+        scene.addItem(s)
+        labels.append(item_label(s))
+
+    assert labels == ["Source", "Source 2", "Source 3"]
+
+
+def test_assign_unique_name_fills_gap(qtbot):
+    from optiverse.objects.annotations.text_note_item import TextNoteItem
+    from optiverse.objects.naming import assign_unique_name, item_label
+
+    scene = QtWidgets.QGraphicsScene()
+    keep = []
+    for _ in range(3):  # Text, Text 2, Text 3
+        t = TextNoteItem("Text")
+        assign_unique_name(scene, t)
+        scene.addItem(t)
+        keep.append(t)
+    scene.removeItem(keep[1])  # remove "Text 2"
+
+    t = TextNoteItem("Text")
+    assign_unique_name(scene, t)
+    assert item_label(t) == "Text 2"  # gap refilled
+
+
+# --------------------------------------------------------------------------- #
+# Persistence round-trips (defects 2 & 3)
+# --------------------------------------------------------------------------- #
+def test_source_name_survives_serialization(qtbot):
+    from optiverse.core.models import SourceParams
+    from optiverse.objects.sources.source_item import SourceItem
+    from optiverse.objects.type_registry import deserialize_item, serialize_item
+
+    src = SourceItem(SourceParams())
+    src.params.name = "Pump Laser"
+    restored = deserialize_item(serialize_item(src))
+    assert restored is not None
+    assert restored.params.name == "Pump Laser"
+
+
+def test_text_display_name_survives_serialization(qtbot):
+    from optiverse.objects.annotations.text_note_item import TextNoteItem
+
+    note = TextNoteItem("hello")
+    note.display_name = "Collimator Label"
+    restored = TextNoteItem.from_dict(note.to_dict())
+    assert restored.display_name == "Collimator Label"


### PR DESCRIPTION
Fixes #103.

## Part 1 — Renaming a layer no longer reverts

Renaming an element in the Layers panel (double-click → type → Enter) reverted to the default name. Three independent causes, which is why every element type was affected:

1. **Editor torn down mid-edit (all types).** A debounced `LayerPanel` refresh (`beginResetModel`/`endResetModel`) or scene-selection sync fired while the inline editor was open — the double-click that starts editing itself changes selection and arms those timers (collaboration / linked-assembly refreshes do the same) — closing the editor before the typed name committed. Fixed by guarding `_do_refresh` (defer) and `_do_sync_from_scene_selection` (skip) while the tree is in `EditingState`. Root cause was confirmed empirically with a headless-Qt harness.
2. **Sources had nowhere to store a name.** `SourceParams` had no `name` field and `SourceItem` no `display_name`, so `RenameNodeCommand` wrote nothing and the label fell back to `"Source"`. Added `SourceParams.name` (round-trips via the `vars()`-based serializer).
3. **Text renames lost on reload.** `TextNoteItem.display_name` wasn't serialized. Now persisted in `to_dict`/`from_dict`.

## Part 2 — Auto-indexing duplicate names (place, drop, paste & duplicate)

New/dropped elements whose default label already exists get a numeric suffix: `Lens → Lens 2 → Lens 3`, `Text → Text 2 → Text 3`. This now also covers **paste and duplicate** (which share the `clone()` path in Optiverse): a batch stays unique against the scene *and* within itself (`Lens 2`/`Lens 3`). The first of a kind keeps its bare name; freed gaps are refilled; autolabels are excluded.

Logic lives in `objects/naming.py` (`item_label` / `set_item_label` / `assign_unique_name` / `assign_unique_names`), which is the single source of truth for label resolution — `LayerItemModel._get_item_name` now delegates to it. Wired at the element-creation sites (toolbar placement, library drop) and both paste paths (same-instance clone + cross-instance). `TextNoteItem.clone()` now also copies `display_name`, so duplicating a renamed note indexes on its real name.

## Verification / tests
- `tests/core/test_naming.py` — Qt-free unit tests (label resolution, single/batch auto-index, gap refill, autolabel exclusion). Runs in CI (which skips `tests/ui`).
- `tests/ui/test_layer_rename_and_autoindex.py` — Qt integration: rename survives a refresh/sync firing mid-edit (source & text), auto-index over real scene items, source/text name serialization round-trips, and `clone()` preserving `display_name`.
- Ruff + mypy clean; existing layer-model / component-canvas-sync / raytracing tests still pass.

## Review
Ran a high-effort self code-review over the full change. No correctness bugs in the diff; applied two cleanups it surfaced — the `_get_item_name`→`item_label` de-duplication and `clone()` preserving `display_name`. Lower-severity notes (skip-sync-during-edit is an intentional trade-off to protect the edit; per-batch scene recomputation is negligible) were left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)