### PR TITLE
Add end-to-end coverage and document conventions for diverging lenses (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Zoom-invariant ruler rendering** (#80): Ruler endpoint bars, labels, selection bounds, and hit-test areas now maintain constant screen size regardless of zoom level, matching the existing cosmetic-pen line behavior
 
+### Documentation
+
+- **Sign and coordinate conventions** (#109): `docs/RAYTRACING_PHYSICS.md` now states that all user-facing angles (`SourceParams.angle_deg` and element `angle_deg`) are measured **clockwise** from +x in Y-up world coordinates (`0°` → right, `90°` → down, `270°`/`-90°` → up), with the same note on `SourceParams` itself. The thin-lens section was updated to the shipped ray-slope law `tan(θ_out) = tan(θ_in) − y/f` (it still documented the superseded angle form), including how a signed `f` gives a real or virtual focus without ever reflecting. Corrected the scene coordinate system description, which claimed Y-down when the canvas view has been Y-up since the `scale(1, -1)` view flip
+
 ### Fixed
 
-- **Negative-focal-length lenses** (#102): Diverging lenses (f < 0) now correctly transmit and diverge rays instead of reflecting them back toward the source. The ideal thin-lens deflection now uses the ray-slope law `tan(θ_out) = tan(θ_in) − y/f`, which focuses an off-axis parallel bundle to a single point (`f·tan θ`) and matches the web engine's tracer
+- **Negative-focal-length lenses** (#102, #109): Diverging lenses (f < 0) now correctly transmit and diverge rays instead of reflecting them back toward the source. The ideal thin-lens deflection now uses the ray-slope law `tan(θ_out) = tan(θ_in) − y/f`, which focuses an off-axis parallel bundle to a single point (`f·tan θ`) and matches the web engine's tracer. End-to-end regression coverage now traces a full `-50`/`+150` Galilean beam expander through `trace_rays_polymorphic`, guarding the propagation direction as well as the deflection
 
 ## [0.3.4] - 2026-04-30
 

--- a/docs/RAYTRACING_PHYSICS.md
+++ b/docs/RAYTRACING_PHYSICS.md
@@ -320,19 +320,23 @@ J_mirror = [[1,  0],
 
 ### 5. Thin Lens Equation
 
-Optiverse uses the **paraxial (thin lens) approximation**:
+Optiverse models an **ideal thin lens** using the exact **ray-slope** law:
 
 #### Thin Lens Formula
 
 ```
-θ_out = θ_in - y/f
+tan(θ_out) = tan(θ_in) - y/f
 ```
 
 where:
-- **θ_in** = incident angle (relative to optical axis)
-- **θ_out** = output angle (relative to optical axis)
-- **y** = height of ray on lens (distance from optical axis)
-- **f** = effective focal length (EFL)
+- **θ_in** = incident angle (relative to the lens normal)
+- **θ_out** = output angle (relative to the lens normal)
+- **y** = height of ray on lens (signed distance from the lens centre)
+- **f** = effective focal length (EFL), **signed**: `f > 0` converging, `f < 0` diverging
+
+This is the *slope* form, not the small-angle form. It is what makes a parallel
+bundle at **any** incidence angle converge to a single point at height `f·tan(θ_in)`
+in the focal plane, for every ray height `y`.
 
 #### Ray Height Calculation
 
@@ -346,31 +350,53 @@ y = (hit_point - center) · tangent
 
 #### Direction Update
 
-**Step 1: Decompose incident direction**
+**Step 1: Orient the normal along propagation, then decompose**
 
 ```
-a_n = direction · normal
-a_t = direction · tangent
-θ_in = atan2(a_t, a_n)
+if direction · normal < 0:  normal = -normal      # normal now points forward
+a_n = direction · normal                          # cos(θ_in) ≥ 0
+a_t = direction · tangent                         # sin(θ_in)
+tan(θ_in) = a_t / a_n
 ```
 
-**Step 2: Apply thin lens equation**
+**Step 2: Apply the ray-slope thin lens law**
 
 ```
-θ_out = θ_in - y/f
+slope = a_t / a_n - y / f
 ```
 
 **Step 3: Reconstruct output direction**
 
 ```
-direction_out = normalize(cos(θ_out)·normal + sin(θ_out)·tangent)
+direction_out = normalize(normal + slope·tangent)
 ```
+
+Building the exit direction as `normal + slope·tangent` — rather than from an
+angle — is what keeps the lens **transmissive for either sign of f**: the
+component along the forward-facing normal is fixed at `+1` before
+normalization, so it can never go negative.
+
+#### Sign of `f`: converging vs. diverging
+
+A **negative** EFL is a diverging lens, not a mirror. A collimated ray at height
+`y` exits with slope `-y/f`, which for `f < 0` has the same sign as `y` — the
+ray bends *away* from the axis, and its backward extension crosses the axis at
+`x = -|f|` (the **virtual** focus, on the incident side):
+
+```
+f = +100 mm, y = -5 mm  →  slope = +0.05,  real focus at x = +100 mm
+f = -50 mm,  y = -5 mm  →  slope = -0.10,  virtual focus at x = -50 mm
+```
+
+In both cases the ray continues **forward**. Reconstructing the direction from
+`atan2(y, f)` instead places `θ_out` in the rear hemisphere when `f < 0` and
+makes the lens reflect — the bug behind issues #102 and #109.
 
 #### Limitations
 
-- **Paraxial approximation**: Only valid for small angles (typically < 10°)
 - **Thin lens**: Assumes lens thickness is negligible
 - **No aberrations**: Does not model spherical aberration, coma, etc.
+- **Tangential plane only**: 2D tracer; no sagittal/tangential split
 
 ---
 
@@ -570,21 +596,23 @@ class IOpticalElement(ABC):
 
 ### 2. Lens (`LensElement`)
 
-**Physics**: Thin lens approximation (paraxial optics)
+**Physics**: Ideal thin lens, exact ray-slope law
 
 **Input**: Ray with direction **v_in**, height **y** on lens
 
 **Process**:
-1. Compute ray height **y** from optical axis
-2. Apply thin lens equation: `θ_out = θ_in - y/f`
-3. Reconstruct output direction
-4. Preserve polarization (ideal lens)
+1. Flip the normal to point along propagation
+2. Compute ray height **y** from the lens centre
+3. Apply the ray-slope law: `slope = tan(θ_in) - y/f`
+4. Reconstruct output direction as `normalize(normal + slope·tangent)` — always forward
+5. Preserve polarization (ideal lens)
 
 **Output**: Single refracted ray
 
 **Equations**:
-- Thin lens: `θ_out = θ_in - y/f`
+- Thin lens: `tan(θ_out) = tan(θ_in) - y/f`
 - No intensity loss (ideal lens)
+- Signed `f`: `f > 0` converges, `f < 0` diverges (never reflects)
 
 ---
 
@@ -685,18 +713,47 @@ class IOpticalElement(ABC):
 
 - **Origin**: Canvas center (0, 0)
 - **X-axis**: Positive right, negative left
-- **Y-axis**: Positive DOWN, negative UP (Y-down, screen convention)
+- **Y-axis**: Positive UP, negative DOWN (Y-up, mathematical convention)
 - **Units**: Millimeters (mm)
 
 ### Conversion
 
-When rendering interfaces from component editor to main canvas:
+Storage and scene coordinates are **both Y-up**, so interface endpoints need no
+flip when a component is placed on the canvas. Qt's own coordinate system is
+Y-down, and that is reconciled in exactly two places:
+
+- `GraphicsView.__init__` applies `scale(1.0, -1.0)` once at the view level, so
+  scene mm are drawn Y-up on screen.
+- `ComponentSprite` applies `scale(1.0, -1.0)` to flip each SVG from its native
+  Y-down pixel space into the Y-up scene.
+
+Items whose text must stay upright despite the view flip (`TextNoteItem`,
+`PathMeasureItem`, `AngleMeasureItem`) re-invert locally while painting.
+
+### Angle Convention
+
+**All user-facing angles — `SourceParams.angle_deg` and every element
+`angle_deg` — are measured CLOCKWISE from the +x axis.** Since the world is
+Y-up, a positive angle rotates from +x toward −y:
+
+| `angle_deg` | Direction   | On screen |
+|-------------|-------------|-----------|
+| `0`         | `(+1,  0)`  | right →   |
+| `90`        | `( 0, -1)`  | down ↓    |
+| `180`       | `(-1,  0)`  | left ←    |
+| `270`/`-90` | `( 0, +1)`  | up ↑      |
+
+Equivalently, for a source:
 
 ```
-y_scene = -y_component  (flip Y-axis)
+direction = (cos(-angle_rad), sin(-angle_rad))
 ```
 
-This conversion happens in `ComponentSprite` during rendering.
+The single sign flip from this clockwise convention to the math
+(counter-clockwise) convention lives in
+`raytracing/engine._generate_rays_from_source`; the equivalent flip for element
+orientation lives in `core.raytracing_math.user_angle_to_qt` /
+`qt_angle_to_user`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,13 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-extend-select = ["E", "F", "I", "UP", "B", "Q", "W"]
+# `select`, not `extend-select`: extend-select *adds to* whatever ruff's default
+# rule set happens to be, so the effective rule set drifted whenever ruff changed
+# that default. ruff 0.16 broadened it (BLE, SIM, RUF, DTZ, PLR, S, EXE, ...) and
+# turned CI red repo-wide on unmodified code. Listing the rules with `select`
+# pins the set the project actually chose. "E" and "F" are supersets of the old
+# default (E4/E7/E9 + F), so this is equivalent to the previous behaviour.
+select = ["E", "F", "I", "UP", "B", "Q", "W"]
 ignore = ["E203"]
 
 [tool.black]

--- a/src/optiverse/core/models.py
+++ b/src/optiverse/core/models.py
@@ -260,9 +260,27 @@ def deserialize_component(data: dict[str, Any], settings_service=None) -> Compon
 
 @dataclass
 class SourceParams:
+    """Emission parameters for a ray or Gaussian-beam source.
+
+    Angle convention (#109): world coordinates are Y-up, and ``angle_deg`` is
+    measured **clockwise** from the +x axis, so a positive angle rotates the
+    emission direction from +x toward −y::
+
+        angle_deg=0    → (+1,  0)   right
+        angle_deg=90   → ( 0, -1)   down
+        angle_deg=180  → (-1,  0)   left
+        angle_deg=270  → ( 0, +1)   up      (same as -90)
+
+    Equivalently ``direction = (cos(-angle_rad), sin(-angle_rad))``; the sign
+    flip to the math (counter-clockwise) convention happens once, in
+    ``optiverse.raytracing.engine._generate_rays_from_source``. Element
+    orientations (``BaseOpticalParams.angle_deg`` and friends) use the same
+    clockwise convention.
+    """
+
     x_mm: float = -400.0
     y_mm: float = 0.0
-    angle_deg: float = 0.0
+    angle_deg: float = 0.0  # Clockwise from +x; see class docstring
     # Custom layer-panel name (None = fall back to the "Source" type label).
     # Without this field a source rename had nowhere to be stored and reverted.
     name: str | None = None

--- a/tests/raytracing/test_engine.py
+++ b/tests/raytracing/test_engine.py
@@ -5,10 +5,12 @@ This tests the complete end-to-end raytracing using IOpticalElement polymorphism
 """
 
 import numpy as np
+import pytest
 
 from optiverse.core.models import SourceParams
 from optiverse.data import LensProperties, LineSegment, MirrorProperties, OpticalInterface
 from optiverse.integration import create_polymorphic_element
+from optiverse.raytracing.elements import LensElement
 from optiverse.raytracing.engine import trace_rays_polymorphic
 
 
@@ -601,3 +603,163 @@ class TestRaySeparationRotation:
             assert (
                 abs(dot_product) < 0.01
             ), f"At {angle}°: Separation should be perpendicular, dot={dot_product}"
+
+
+class TestNegativeFocalLengthEndToEnd:
+    """Regression (#109): diverging lenses must not send rays backwards.
+
+    `TestLensElement.test_negative_focal_length_diverges_forward` already covers
+    `LensElement.interact()` in isolation. These tests exercise the same physics
+    through the full tracer — source generation, intersection, propagation — which
+    is the level at which #109 was reported: the reported symptom was final path
+    points at negative x, i.e. a wrong *propagation* direction rather than a wrong
+    deflection.
+    """
+
+    @staticmethod
+    def _source() -> SourceParams:
+        """Collimated 3-ray bundle at y = -5, 0, +5 travelling in +x from x=-200."""
+        return SourceParams(
+            x_mm=-200.0,
+            y_mm=0.0,
+            angle_deg=0.0,
+            spread_deg=0.0,
+            n_rays=3,
+            size_mm=10.0,
+            ray_length_mm=600.0,
+            wavelength_nm=780.0,
+            color_hex="#FF0000",
+            polarization_type="horizontal",
+        )
+
+    def test_negative_efl_propagates_forward(self):
+        """Every segment of every path must keep travelling in +x."""
+        lens = LensElement(p1=np.array([0.0, -25.4]), p2=np.array([0.0, 25.4]), efl_mm=-50.0)
+
+        paths = trace_rays_polymorphic([lens], [self._source()], max_events=10)
+
+        assert len(paths) == 3
+        for path in paths:
+            pts = np.asarray(path.points)
+            # Monotonically increasing x: a reflected ray would turn this around.
+            dx = np.diff(pts[:, 0])
+            assert np.all(dx > 0), f"Ray propagates backwards: {pts.tolist()}"
+
+    def test_negative_efl_axial_ray_is_undeviated(self):
+        """The clearest tell from #109: an on-axis ray must exit at +x, y=0.
+
+        An ideal thin lens leaves a ray through its centre undeviated, so the sign
+        of the exit x is set purely by the propagation step. The bug produced
+        (-400, 0) here.
+        """
+        lens = LensElement(p1=np.array([0.0, -25.4]), p2=np.array([0.0, 25.4]), efl_mm=-50.0)
+
+        paths = trace_rays_polymorphic([lens], [self._source()], max_events=10)
+
+        axial = min(paths, key=lambda p: abs(p.points[0][1]))
+        end = axial.points[-1]
+        # 600 mm of ray length starting 200 mm before the lens → ends at x=+400.
+        assert end[0] == pytest.approx(400.0, abs=1.0)
+        assert end[1] == pytest.approx(0.0, abs=1e-6)
+
+    def test_negative_efl_diverges_from_virtual_focus(self):
+        """Marginal rays must bend away from the axis, from a virtual focus at x=-|f|.
+
+        A collimated ray at height y exits with slope −y/f (f<0 → same sign as y),
+        so back-extending the exit ray crosses the axis at x = −|f| on the incident
+        side. That is the defining property of a diverging lens.
+        """
+        f = -50.0
+        lens = LensElement(p1=np.array([0.0, -25.4]), p2=np.array([0.0, 25.4]), efl_mm=f)
+
+        paths = trace_rays_polymorphic([lens], [self._source()], max_events=10)
+
+        for path in paths:
+            pts = np.asarray(path.points)
+            y_in = pts[0][1]
+            if abs(y_in) < 1e-9:
+                continue  # axial ray covered above
+
+            exit_dir = pts[-1] - pts[-2]
+            # Slope alone cannot distinguish a diverging ray from its backwards
+            # twin (the #109 bug produced the correct slope on a reversed ray).
+            assert exit_dir[0] > 0, f"Exit ray travels backwards: {pts.tolist()}"
+            slope = exit_dir[1] / exit_dir[0]
+            # tan(θ_out) = tan(θ_in) − y/f = 0 − y/(−50) = y/50
+            assert slope == pytest.approx(-y_in / f, rel=1e-6)
+            # Diverging: exit slope carries the ray further from the axis.
+            assert slope * y_in > 0, "Diverging lens must bend rays away from the axis"
+
+            # Back-extend from the lens plane (x=0, y=y_in) to the axis.
+            virtual_focus_x = -y_in / slope
+            assert virtual_focus_x == pytest.approx(f, rel=1e-6)
+
+    def test_galilean_telescope_expands_and_stays_collimated(self):
+        """The layout from #109: a −50 / +150 Galilean beam expander.
+
+        Separation f1 + f2 = 100 mm gives an afocal system with 3× magnification.
+        Rays must exit forward, collimated, at 3× the input height — the bug made
+        this bundle travel away from the source instead.
+        """
+        l1 = LensElement(p1=np.array([0.0, -30.0]), p2=np.array([0.0, 30.0]), efl_mm=-50.0)
+        l2 = LensElement(p1=np.array([100.0, -60.0]), p2=np.array([100.0, 60.0]), efl_mm=150.0)
+        source = self._source()
+        source.x_mm = -100.0
+        source.ray_length_mm = 500.0
+
+        paths = trace_rays_polymorphic([l1, l2], [source], max_events=10)
+
+        assert len(paths) == 3
+        for path in paths:
+            pts = np.asarray(path.points)
+            # source → lens 1 → lens 2 → end
+            assert len(pts) == 4, f"Expected two lens hits, got {pts.tolist()}"
+            assert np.all(np.diff(pts[:, 0]) > 0), "Bundle must keep travelling in +x"
+
+            y_in = pts[0][1]
+            assert pts[2][1] == pytest.approx(3.0 * y_in, rel=1e-6), "3× expansion at lens 2"
+
+            exit_dir = pts[-1] - pts[-2]
+            assert exit_dir[1] / exit_dir[0] == pytest.approx(0.0, abs=1e-9), "Afocal output"
+
+
+class TestSourceAngleConvention:
+    """`SourceParams.angle_deg` is measured clockwise from +x (documented in #109).
+
+    World coordinates are Y-up (the canvas view applies a single Y flip), so a
+    positive angle rotates the emission direction from +x toward −y. This is easy
+    to get backwards when authoring layouts programmatically, so pin it down.
+    """
+
+    @staticmethod
+    def _direction(angle_deg: float) -> np.ndarray:
+        source = SourceParams(
+            x_mm=0.0,
+            y_mm=0.0,
+            angle_deg=angle_deg,
+            spread_deg=0.0,
+            n_rays=1,
+            size_mm=0.0,
+            ray_length_mm=100.0,
+            wavelength_nm=633.0,
+            color_hex="#FF0000",
+            polarization_type="horizontal",
+        )
+        paths = trace_rays_polymorphic([], [source], max_events=1)
+        assert len(paths) == 1
+        pts = np.asarray(paths[0].points)
+        delta = pts[-1] - pts[0]
+        return delta / np.linalg.norm(delta)
+
+    @pytest.mark.parametrize(
+        ("angle_deg", "expected"),
+        [
+            (0.0, (1.0, 0.0)),  # +x (right)
+            (90.0, (0.0, -1.0)),  # −y
+            (180.0, (-1.0, 0.0)),  # −x (left)
+            (270.0, (0.0, 1.0)),  # +y
+            (-90.0, (0.0, 1.0)),  # +y
+        ],
+    )
+    def test_positive_angle_rotates_clockwise(self, angle_deg, expected):
+        assert self._direction(angle_deg) == pytest.approx(np.array(expected), abs=1e-9)


### PR DESCRIPTION
Closes #109.

## The reported bug does not reproduce on current `main`

Running the issue's repro verbatim against `main` (19a2cdf):

```
efl_mm=-50.0
    ['(-200,-5.0)', '(0,-5.0)', '(398,-44.8)']   <- forward, diverging
    ['(-200,0.0)',  '(0,0.0)',  '(400,0.0)']
    ['(-200,5.0)',  '(0,5.0)',  '(398,44.8)']
```

It was fixed by #106 (merged 2026-07-10, ~5 weeks before the issue was filed), which replaced the `atan2(y, f)` deflection with the ray-slope law `tan(θ_out) = tan(θ_in) − y/f` and builds the exit direction as `normal + slope·tangent`, whose forward component cannot go negative. The issue was filed against a checkout predating that merge.

The issue's Galilean telescope now works as intended — `-50`/`+150` at 100 mm separation gives an afocal 3× expander:

```
[(-100.00,-5.000), (0.00,-5.000), (100.00,-15.000), (399.50,-15.000)]  exit slope: 0.0
[(-100.00, 0.000), (0.00, 0.000), (100.00,  0.000), (400.00,  0.000)]  exit slope: 0.0
[(-100.00, 5.000), (0.00, 5.000), (100.00, 15.000), (399.50, 15.000)]  exit slope: 0.0
```

One note on the issue's **Expected** section: it predicts the `h = -5` ray reaching `(400, +45)` via `slope ≈ h/|f|`. The correct law is `slope = -y/f = -(-5)/(-50) = -0.1`, giving `(400, -45)` — the ray bends *away* from the axis on the same side, back-extending to the virtual focus at `x = -50`. Current output matches that.

## What was actually missing: coverage at the reported level

The existing regression test calls `LensElement.interact()` directly, so it checks the *deflection* but not the *propagation* — and this bug's signature was a reversed propagation direction. I verified the gap rather than assuming it: with the pre-#106 lens restored, the new tests fail and reproduce the issue's exact numbers, `(-398.0, 34.8)`. Notably the old-style slope-only assertion **still passed** on the buggy code, because a reversed ray carries the correct slope — so that test alone could never have caught this.

New tests in `tests/raytracing/test_engine.py`, all through `trace_rays_polymorphic`:

| Test | Guards |
|---|---|
| `test_negative_efl_propagates_forward` | `x` strictly increases along every path segment |
| `test_negative_efl_axial_ray_is_undeviated` | the issue's clearest tell: axial ray ends at `+400`, not `-400` |
| `test_negative_efl_diverges_from_virtual_focus` | slope `= -y/f`, bends away from axis, virtual focus at `x = -\|f\|` |
| `test_galilean_telescope_expands_and_stays_collimated` | the issue's real layout: afocal, 3×, forward |

All four fail on the pre-#106 lens and pass on `main`.

## Documentation

The issue's second request — `SourceParams.angle_deg` is clockwise and undocumented. It was stated only in the `user_angle_to_qt()` helper docstring, nowhere in `docs/` or on `SourceParams` itself. Now documented in both, verified empirically (`0` → right, `90` → down, `180` → left, `270`/`-90` → up) and pinned by a parametrized test.

While in `docs/RAYTRACING_PHYSICS.md` I corrected two stale sections that actively mislead anyone diagnosing exactly this bug:

- **Thin lens** still documented the superseded `θ_out = θ_in − y/f` with `atan2` reconstruction — i.e. the formulation that *caused* #102/#109. Updated to the shipped ray-slope law, with a new section on how signed `f` gives a real or virtual focus without ever reflecting.
- **Coordinate systems** claimed the scene is Y-down and that `y_scene = -y_component`. The canvas view has applied `scale(1, -1)` since `GraphicsView` gained its Y-up flip; storage→scene is offset + `mapToScene` with no Y flip at all (verified in `component_item.py:341-351`). The only Y flips are the view-level one and `ComponentSprite`'s SVG pixel-space flip.

## Unrelated CI fix: `select` instead of `extend-select` (2nd commit)

CI initially failed here with **232 ruff errors**, nearly all in files this PR never touches (`examples/`, `tools/`, unrelated `src/` modules). That is a config problem, not a code problem, and it was **pre-existing** — I verified rather than assumed it:

```
$ git worktree add /tmp/main-clean origin/main   # untouched main, no changes from this PR
$ ruff-0.16.3 check .
Found 232 errors.                                 # identical count to CI
```

`extend-select` *adds to* whatever ruff's default rule set happens to be, so the effective rule set drifts whenever ruff changes that default. `ruff>=0.6.0` is unpinned in the dev extra, and ruff 0.16 broadened the default set considerably — `BLE`, `SIM`, `RUF`, `DTZ`, `PLR`, `S`, `EXE` and more, none of which this project opted into. `main`'s last green run was 2026-07-10, predating that release; any PR opened today would hit this.

Switching to `select` states the rule set the project actually chose, so it stops moving with ruff's defaults. `"E"` and `"F"` are supersets of the old default (`E4`/`E7`/`E9` and `F`), so this is **exactly equivalent** to the previous effective set — verified clean repo-wide on both ruff 0.15.8 and 0.16.3.

This leaves `ruff>=0.6.0` unpinned, so new rules added *within* the selected prefixes could still surface later. Pinning is a separate maintainer call I didn't make here.

## Testing

- `tests/raytracing`, `tests/integration`, `tests/data` — all pass
- `ruff check .` clean repo-wide on both ruff 0.15.8 and CI's 0.16.3
- `mypy src/` — success, 135 source files
- `tests/core` and `tests/examples` abort with a Qt fixture-setup fault in my local env; confirmed identical on unmodified `main`, so it's environmental. CI (ubuntu + xvfb) is the authority and was green on `main`
- Pre-existing `ruff format` deviations in the two touched Python files were left alone to keep the diff reviewable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
